### PR TITLE
[FIX] 레이아웃 컴포넌트에 푸터 표시 제어 기능 추가

### DIFF
--- a/src/components/layout/PageLayout.tsx
+++ b/src/components/layout/PageLayout.tsx
@@ -4,25 +4,25 @@ import Footer from './Footer/Footer';
 
 interface LayoutProps {
   children: React.ReactNode;
-  showHeader: boolean;
-  showNavbar: boolean;
+  showHeader?: boolean;
+  showNavbar?: boolean;
+  showFooter?: boolean;
+  footerVariant?: 'dark' | 'light';
 }
 
 const PageLayout = ({
   children,
   showHeader = true,
   showNavbar = true,
+  showFooter = true,
+  footerVariant = 'dark',
 }: LayoutProps) => {
-  footerVariant?: 'dark' | 'light';
-}
-
-const PageLayout = ({ children, footerVariant = 'dark' }: LayoutProps) => {
   return (
     <div className="min-h-screen flex flex-col">
       {showHeader && <Header />}
       {showNavbar && <HeaderNav />}
       <main className="flex-1">{children}</main>
-      <Footer variant={footerVariant} />
+      {showFooter && <Footer variant={footerVariant} />}
     </div>
   );
 };

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -2,7 +2,12 @@ import Layout from '../components/layout/PageLayout';
 
 const Home = () => {
   return (
-    <Layout showHeader={true} showNavbar={true}>
+    <Layout
+      showHeader={true}
+      showNavbar={true}
+      showFooter={true}
+      footerVariant="light"
+    >
       <div className="p-6">
         <h1 className="text-3xl font-bold mb-4">Reform-FE</h1>
         <p className="text-gray-600 mb-6">내폼리폼 임시화면입니다.</p>


### PR DESCRIPTION
## 작업 내용
- `PageLayout` 컴포넌트에 `showFooter` prop을 추가하여 페이지별로 푸터 표시 여부를 제어할 수 있도록 개선
- `PageLayout` 두 번 선언되어 있는 문제 해결


## 변경 사항
- `showFooter?: boolean` prop 추가 (기본값: `true`)


