### PR TITLE
[FE] 마이페이지 배송지 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "lucide-react": "^0.562.0",
         "react": "^19.2.0",
         "react-calendar": "^6.0.0",
+        "react-daum-postcode": "^3.2.0",
         "react-dom": "^19.2.0",
         "react-router-dom": "^7.1.3",
         "swiper": "^12.0.3",
@@ -8775,6 +8776,15 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-daum-postcode": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/react-daum-postcode/-/react-daum-postcode-3.2.0.tgz",
+      "integrity": "sha512-NHY8TUicZXMqykbKYT8kUo2PEU7xu1DFsdRmyWJrLEUY93Xhd3rEdoJ7vFqrvs+Grl9wIm9Byxh3bI+eZxepMQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/react-docgen": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "lucide-react": "^0.562.0",
     "react": "^19.2.0",
     "react-calendar": "^6.0.0",
+    "react-daum-postcode": "^3.2.0",
     "react-dom": "^19.2.0",
     "react-router-dom": "^7.1.3",
     "swiper": "^12.0.3",

--- a/src/components/domain/mypage/NormalMyPage/MyInfoPage.tsx
+++ b/src/components/domain/mypage/NormalMyPage/MyInfoPage.tsx
@@ -2,7 +2,14 @@ import { useState } from 'react';
 import { Camera } from 'lucide-react';
 import Button from '../../../common/Button/button2';
 import NicknameModal from '../NicknameModal';
-import DaumPostcode, { type AddressData } from 'react-daum-postcode';
+import DaumPostcode from 'react-daum-postcode';
+
+type AddressData = {
+  zonecode: string;
+  roadAddress: string;
+  jibunAddress?: string;
+  address: string;
+};
 
 type EditField = null | 'nickname' | 'phone' | 'email' | 'address';
 
@@ -14,7 +21,6 @@ const MyInfoPage = () => {
   const [editField, setEditField] = useState<EditField>(null);
   const [isPostcodeOpen, setIsPostcodeOpen] = useState(false);
 
-  // 배송지 관련 상태 (이미지에 맞춰 확장)
   const [address, setAddress] = useState({
     recipient: '',
     phone: '',

--- a/src/components/domain/mypage/NormalMyPage/MyInfoPage.tsx
+++ b/src/components/domain/mypage/NormalMyPage/MyInfoPage.tsx
@@ -2,14 +2,28 @@ import { useState } from 'react';
 import { Camera } from 'lucide-react';
 import Button from '../../../common/Button/button2';
 import NicknameModal from '../NicknameModal';
+import DaumPostcode, { type AddressData } from 'react-daum-postcode';
 
 type EditField = null | 'nickname' | 'phone' | 'email' | 'address';
 
 const MyInfoPage = () => {
   const [showNicknameModal, setShowNicknameModal] = useState(false);
-
   const [nickname, setNickname] = useState('심심한 리본');
-  /* 마스킹 함수 추가 */
+  const [phone, setPhone] = useState('010-1111-0000');
+  const [email, setEmail] = useState('example@gmail.com');
+  const [editField, setEditField] = useState<EditField>(null);
+  const [isPostcodeOpen, setIsPostcodeOpen] = useState(false);
+
+  // 배송지 관련 상태 (이미지에 맞춰 확장)
+  const [address, setAddress] = useState({
+    recipient: '',
+    phone: '',
+    zip: '04310',
+    addr1: '서울 용산구 청파로47길 100',
+    addr2: '명신관 302호',
+  });
+
+  /* 마스킹 함수 */
   const maskName = (name: string) => {
     if (name.length <= 1) return '*';
     if (name.length === 2) return name[0] + '*';
@@ -18,27 +32,27 @@ const MyInfoPage = () => {
   };
 
   const maskPhone = (phone: string) => {
-    // 전화번호 010-1234-5678 -> 010-****-5678
     return phone.replace(/(\d{3})-(\d{4})-(\d{4})/, '$1-****-$3');
   };
 
-  const [phone, setPhone] = useState('010-1111-0000');
-  const [email, setEmail] = useState('example@gmail.com');
+  const handleComplete = (data: AddressData) => {
+    setAddress((prev) => ({
+      ...prev,
+      zip: data.zonecode,
+      addr1: data.roadAddress || data.address,
+    }));
 
-  const [address, setAddress] = useState({
-    zip: '04310',
-    addr1: '서울 용산구 청파로47길 100',
-    addr2: '명신관 302호',
-  });
+    setIsPostcodeOpen(false);
+  };
 
-  const [editField, setEditField] = useState<EditField>(null);
+
 
   return (
     <>
       <div className="max-w-6xl mx-auto pb-10 pt-5 bg-white">
         <div className="flex flex-col md:flex-row gap-12">
           
-          {/* 프로필 이미지 */}
+          {/* 프로필 이미지 (유지) */}
           <div className="flex-shrink-0">
             <div className="relative w-32 h-32">
               <img
@@ -46,7 +60,6 @@ const MyInfoPage = () => {
                 alt="Profile"
                 className="w-full h-full rounded-full object-cover"
               />
-
               <button className="absolute bottom-0 right-0 bg-slate-500 p-2 rounded-full text-white" title="사진 추가">
                 <Camera size={18} />
               </button>
@@ -55,14 +68,13 @@ const MyInfoPage = () => {
 
           {/* 정보 영역 */}
           <div className="flex-grow">
-
-            {/* 성명 */}
+            {/* 성명 (유지) */}
             <div className="flex items-center py-6 border-b border-[var(--color-line-gray-40)]">
               <span className="w-32 body-b0-sb text-[var(--color-gray-60)]">성명</span>
               <span className="body-b0-sb">{maskName('홍길동')}</span>
             </div>
 
-            {/* 닉네임 */}
+            {/* 닉네임 (유지) */}
             <div className="flex items-center py-6 border-b border-[var(--color-line-gray-40)]">
               <span className="w-32 body-b0-sb text-[var(--color-gray-60)]">닉네임</span>
               <span className="flex-grow body-b0-sb">{nickname}</span>
@@ -71,10 +83,9 @@ const MyInfoPage = () => {
               </Button>
             </div>
 
-            {/* 연락처 */}
+            {/* 연락처 (유지) */}
             <div className="flex items-center py-6 border-b border-[var(--color-line-gray-40)]">
               <span className="w-32 body-b0-sb text-[var(--color-gray-60)]">연락처</span>
-
               <div className="flex-grow">
                 {editField === 'phone' ? (
                   <input
@@ -87,21 +98,14 @@ const MyInfoPage = () => {
                   <span className="body-b0-sb">{maskPhone(phone)}</span>
                 )}
               </div>
-
-              <Button
-                className="!px-12 !py-3 mr-20"
-                onClick={() =>
-                  setEditField(editField === 'phone' ? null : 'phone')
-                }
-              >
+              <Button className="!px-12 !py-3 mr-20" onClick={() => setEditField(editField === 'phone' ? null : 'phone')}>
                 변경하기
               </Button>
             </div>
 
-            {/* 이메일 */}
+            {/* 이메일 (유지) */}
             <div className="flex items-center py-6 border-b border-[var(--color-line-gray-40)]">
               <span className="w-32 body-b0-sb text-[var(--color-gray-60)]">이메일</span>
-
               <div className="flex-grow">
                 {editField === 'email' ? (
                   <input
@@ -114,81 +118,176 @@ const MyInfoPage = () => {
                   <span className="body-b0-sb">{email}</span>
                 )}
               </div>
-
-              <Button
-                className="!px-12 !py-3 mr-20"
-                onClick={() =>
-                  setEditField(editField === 'email' ? null : 'email')
-                }
-              >
+              <Button className="!px-12 !py-3 mr-20" onClick={() => setEditField(editField === 'email' ? null : 'email')}>
                 변경하기
               </Button>
             </div>
 
-            {/* 배송지 */}
-            <div className="flex items-start py-6">
+            {/* --- 배송지 등록 --- */}
+            <div className="flex py-10 border-b border-[var(--color-line-gray-40)]">
               <span className="w-32 body-b0-sb text-[var(--color-gray-60)] pt-2">
-                배송지
+                배송지 등록
               </span>
 
-              <div className="flex-grow flex flex-col gap-2">
-                {editField === 'address' ? (
-                  <>
+              <div className="flex-grow max-w-2xl space-y-6">
+                {/* 받으시는 분 */}
+                <div>
+                  <label className="block body-b0-sb mb-2 pt-2">
+                    받으시는 분 <span className="text-[var(--color-red-1)]">*</span>
+                  </label>
+                  <div className="grid grid-cols-[1fr_160px] gap-3">
                     <input
-                      title="우편 번호"
-                      value={address.zip}
-                      onChange={(e) =>
-                        setAddress({ ...address, zip: e.target.value })
-                      }
-                      className="w-full max-w-md border rounded-md px-3 py-3"
+                      type="text"
+                      className="bg-[var(--color-gray-20)] p-4 outline-none"
+                      placeholder="이름을 입력해주세요."
                     />
-                    <input
-                      title="도로명 주소"
-                      value={address.addr1}
-                      onChange={(e) =>
-                        setAddress({ ...address, addr1: e.target.value })
-                      }
-                      className="w-full max-w-md border rounded-md px-3 py-3"
-                    />
-                    <input
-                      title="상세 주소"
-                      value={address.addr2}
-                      onChange={(e) =>
-                        setAddress({ ...address, addr2: e.target.value })
-                      }
-                      className="w-full max-w-md border rounded-md px-3 py-3"
-                    />
-                  </>
-                ) : (
-                  <>
-                    <div className="bg-[var(--color-gray-20)] body-b0-rg p-3 max-w-md mr-3">
-                      {address.zip}
-                    </div>
-                    <div className="bg-[var(--color-gray-20)] p-3 body-b0-rg max-w-md">
-                      {address.addr1}
-                    </div>
-                    <div className="bg-[var(--color-gray-20)] p-3 body-b0-rg max-w-md">
-                      {address.addr2}
-                    </div>
-                  </>
-                )}
-              </div>
+                    <div />
+                  </div>
+                </div>
 
-              <Button
-                className="!px-12 !py-3 mr-20"
-                onClick={() =>
-                  setEditField(editField === 'address' ? null : 'address')
-                }
-              >
-                변경하기
-              </Button>
+                {/* 휴대폰 번호 */}
+                <div>
+                  <label className="block body-b0-sb mb-2">
+                    휴대폰 번호 <span className="text-[var(--color-red-1)]">*</span>
+                  </label>
+                  <div className="grid grid-cols-[1fr_160px] gap-3">
+                    <input
+                      type="text"
+                      className="bg-[var(--color-gray-20)] p-4 outline-none"
+                      placeholder="번호를 입력해주세요."
+                    />
+                    <div />
+                  </div>
+                </div>
+
+                {/* 배송 주소 */}
+                <div>
+                  <label className="block body-b0-sb mb-2">
+                    배송 주소 <span className="text-[var(--color-red-1)]">*</span>
+                  </label>
+
+                  <div className="space-y-3">
+                    {/* 우편번호 */}
+                    <div className="grid grid-cols-[1fr_160px] gap-3">
+                      <input
+                        type="text"
+                        value={address.zip}
+                        readOnly
+                        className="bg-[var(--color-gray-20)] p-4 outline-none"
+                        placeholder="우편번호"
+                      />
+                      <Button 
+                        className="!px-8 !py-3 whitespace-nowrap"
+                        onClick={() => setIsPostcodeOpen(true)}>
+                        우편번호 검색
+                      </Button>
+                    </div>
+
+                    {/* 기본 주소 */}
+                    <div className="grid grid-cols-[1fr_160px] gap-3">
+                      <input
+                        type="text"
+                        value={address.addr1}
+                        readOnly
+                        className="bg-[var(--color-gray-20)] p-4 outline-none"
+                        placeholder="주소"
+                      />
+                      <div />
+                    </div>
+
+                    {/* 상세 주소 */}
+                    <div className="grid grid-cols-[1fr_160px] gap-3">
+                      <input
+                        type="text"
+                        className="bg-[var(--color-gray-20)] p-4 outline-none"
+                        placeholder="상세주소"
+                      />
+                      <div />
+                    </div>
+                  </div>
+                </div>
+
+                {/* 기본 배송지 체크 */}
+                <div className="flex items-center gap-2">
+                  <input
+                    type="checkbox"
+                    id="default-addr"
+                    className="w-5 h-5 accent-[var(--color-mint-1)]"
+                  />
+                  <label
+                    htmlFor="default-addr"
+                    className="body-b2-rg text-[var(--color-gray-60)] cursor-pointer"
+                  >
+                    기본 배송지로 설정
+                  </label>
+                </div>
+
+                {/* 등록 버튼 */}
+                <div className="grid grid-cols-[1fr] gap-3">
+                  <button
+                    className="py-4 border border-[var(--color-mint-1)]
+                              text-[var(--color-mint-1)] body-b0-bd rounded-[0.625rem]"
+                  >
+                    배송지 등록하기
+                  </button>
+                  <div />
+                </div>
+
+              </div>
             </div>
+
+
+            {/* --- 배송지 관리 섹션 --- */}
+            <div className="flex py-10">
+              <span className="w-32 body-b0-sb text-[var(--color-gray-60)] pt-2">
+                배송지 관리
+              </span>
+              
+              <div className="flex-grow max-w-2xl space-y-6">
+                <div className="space-y-4">
+                  {/* 배송지 카드 1 */}
+                  <div className="border border-[var(--color-line-gray-40)] rounded-lg px-6 py-4 relative">
+                    <div className="flex items-center gap-3 mb-3">
+                      <span className="px-2 py-0.5 bg-[var(--color-mint-6)]
+                                      text-[var(--color-mint-1)] body-b4-sb rounded-[0.3rem]">
+                        기본 배송지
+                      </span>
+                      <span className="body-b1-md">홍길동</span>
+                    </div>
+                    <p className="body-b1-rg text-[var(--color-gray-60)] mb-1">
+                      010-0000-0000
+                    </p>
+                    <p className="body-b1-rg text-[var(--color-gray-60)]">
+                      (04310) 서울 용산구 청파로 47길 100 명신관 301호
+                    </p>
+                    <button className="absolute top-4 right-6 text-[var(--color-gray-50)] body-b3-sb">
+                      삭제
+                    </button>
+                  </div>
+
+                  {/* 배송지 카드 2 */}
+                  <div className="border border-[var(--color-line-gray-40)] rounded-lg px-6 py-4 relative">
+                    <span className="body-b1-md mb-3 block">홍길동</span>
+                    <p className="body-b1-rg text-[var(--color-gray-60)] mb-1">
+                      010-0000-0000
+                    </p>
+                    <p className="body-b1-rg text-[var(--color-gray-60)]">
+                      (04310) 서울 용산구 청파로 47길 100 명신관 301호
+                    </p>
+                    <button className="absolute top-4 right-6 text-[var(--color-gray-50)] body-b3-sb">
+                      삭제
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+
 
           </div>
         </div>
       </div>
 
-      {/* 닉네임 모달 */}
+      {/* 닉네임 모달 (유지) */}
       {showNicknameModal && (
         <NicknameModal
           isOpen={showNicknameModal}
@@ -196,6 +295,22 @@ const MyInfoPage = () => {
           onClose={() => setShowNicknameModal(false)}
           onSave={(newNickname) => setNickname(newNickname)}
         />
+      )}
+      {isPostcodeOpen && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
+          <div className="bg-white p-6 rounded-lg w-[720px] max-w-[90vw] h-[520px] flex flex-col">
+            <DaumPostcode
+              onComplete={handleComplete}
+              autoClose
+            />
+            <button
+              className="mt-4 text-sm text-gray-500"
+              onClick={() => setIsPostcodeOpen(false)}
+            >
+              닫기
+            </button>
+          </div>
+        </div>
       )}
     </>
   );


### PR DESCRIPTION
## 📌 PR 개요
> 마이 페이지에서 배송지 UI를 추가하였음

## 🎯 작업 내용
- 마이페이지에서 배송지 관리 UI 추가
- react-daum-postcode 다운 후 도로명 주소 검색 기능 구현

## 🔗 관련 이슈 / 티켓
- Close #

## 🧩 작업 범위
- [x] UI
- [ ] API 연동
- [ ] 상태 관리
- [ ] 라우팅
- [ ] 공용 컴포넌트
- [x] 스타일

## 📸 스크린샷 / 영상
| Before | After |
|--------|--------|
|     
<img width="2273" height="1522" alt="image" src="https://github.com/user-attachments/assets/054c32a7-17cc-4294-930f-e4c3647a61e1" />
   |      
<img width="2824" height="3360" alt="image" src="https://github.com/user-attachments/assets/40192cd8-0030-40b4-987e-a165538f536e" />
  |


## ⚠️ 리뷰어에게 요청할 사항
> 특히 봐줬으면 하는 부분을 적어주세요.
- Daum Postcode 모달 정상 표시
- Daum Postcode에서 AddressData를 불러왔는데 deploy 오류로 따로 interface로 재정의했음. 타입 처리 관련 검토 부탁드립니다.

## 🚨 주의사항 / 배포 전 체크
- [x] console.log 제거
- [x] 불필요한 주석 제거
- [x] 환경변수(.env) 변경 없음
- [x] 타입 에러 없음
