### PR TITLE
[FIX] 리폼러 마이페이지 UI 수정

### DIFF
--- a/src/components/domain/mypage/EditProfile.tsx
+++ b/src/components/domain/mypage/EditProfile.tsx
@@ -1,12 +1,13 @@
 import { useNavigate } from 'react-router-dom';
 import star from '../../../assets/icons/star.svg';
+import Profile from '../../../assets/icons/profile.svg';
 
 // 데이터 구조 정의
 interface ProfileData {
   level: number;
   nickname: string;
   rating: number;
-  profileImageUrl: string;
+  profileImageUrl?: string;
   tags: string[];
   description: string;
 }
@@ -15,10 +16,12 @@ const mockProfile: ProfileData = {
   level: 3,
   nickname: '침착한 대머리독수리',
   rating: 4.97,
-  profileImageUrl: '/api/placeholder/100/100',
+  //profileImageUrl: '/api/placeholder/100/100',
   tags: ['빠른', '친절한'],
   description: `- 2019년부터 리폼 공방 운영 시작 ✨\n- 6년차 스포츠 의류 리폼 전문 공방\n\n고객님들의 요청과 아쉬움을 담아, 버리지 못하고 잠들어 있던 옷에 새로운 가치와 트렌디한 디자인을 더하는 리폼을 선보이고 있어요. 1:1 맞춤 리폼 제작부터 완성 제품까지 모두 주문 가능합니다.`
 };
+
+const DEFAULT_PROFILE_IMAGE = Profile;
 
 const EditProfile = ({ mode }: { mode: 'edit' | 'view' }) => {
   const navigate = useNavigate();
@@ -27,11 +30,15 @@ const EditProfile = ({ mode }: { mode: 'edit' | 'view' }) => {
       <div className="flex gap-10">
         {/* 1. 프로필 이미지 */}
         <div className="flex-shrink-0">
-          <div className="w-24 h-24 md:w-32 md:h-32 rounded-full overflow-hidden bg-gray-200 border border-gray-100">
-            <img src={mockProfile.profileImageUrl} alt="Profile" className="w-full h-full object-cover" />
+          <div className="w-24 h-24 md:w-32 md:h-32 rounded-full overflow-hidden bg-gray-200 border border-[var(--color-gray-30)]">
+            <img
+              src={mockProfile.profileImageUrl || DEFAULT_PROFILE_IMAGE}
+              alt="Profile"
+              className={`w-full h-full object-cover transition-transform duration-200 
+                ${!mockProfile.profileImageUrl ? "scale-140" : ""}`}
+            />
           </div>
         </div>
-
         {/* 2. 우측 콘텐츠 */}
         <div className="flex-1">
           <div className="flex justify-between items-start mb-6">

--- a/src/components/domain/mypage/MyPageTab.tsx
+++ b/src/components/domain/mypage/MyPageTab.tsx
@@ -1,10 +1,11 @@
-
+import Profile from '../../../assets/icons/profile.svg';
 
 interface MyPageTabsProps<T extends string> {
   tabs: readonly T[];
   activeTab: T;
   onChangeTab: (tab: T) => void;
   displayName: string;
+  profileImageUrl?: string | null;
 }
 
 const MyPageTabs = <T extends string>({
@@ -12,7 +13,9 @@ const MyPageTabs = <T extends string>({
   activeTab,
   onChangeTab,
   displayName,
+  profileImageUrl,
 }: MyPageTabsProps<T>) => {
+  const DEFAULT_PROFILE_IMAGE = Profile;
   
   return (
     <div className="w-[15rem] flex flex-col items-start">
@@ -20,7 +23,15 @@ const MyPageTabs = <T extends string>({
       {/* 1. 상단 프로필 섹션 */}
       <div className="flex items-center gap-3 mb-6 pb-4 border-b border-[var(--color-line-gray-40)] w-full">
         {/* 프로필 이미지 (회색 처리) */}
-        <div className="w-12 h-12 rounded-full border border-[var(--color-gray-30)] flex-shrink-0" />
+        <div className="w-12 h-12 rounded-full border border-[var(--color-gray-30)] flex-shrink-0">
+          <img
+            src={profileImageUrl || DEFAULT_PROFILE_IMAGE}
+            alt="Profile"
+                className={`object-cover w-full h-full ${
+              !profileImageUrl ? "scale-145" : ""
+            }`}
+          />
+        </div>
         {/* 유저 닉네임 */}
         <span className="body-b1-sb text-black">{displayName}</span>
       </div>

--- a/src/pages/my-page-Reform/EditProfilePage.tsx
+++ b/src/pages/my-page-Reform/EditProfilePage.tsx
@@ -93,7 +93,7 @@ const EditProfilePage = () => {
                                 placeholder='프로필에 노출될 소개글을 작성해주세요.'
                                 className="w-full text-[var(--color-gray-50)] body-b1-rg leading-relaxed outline-none resize-none bg-transparent"
                             />
-                            <div className="absolute -bottom-0 -right-16 text-sm text-[var(--color--gray-60)] font-light">
+                            <div className="absolute -bottom-0 -right-20 text-sm text-[var(--color--gray-60)]">
                                 {description.length}/{MAX_DESCRIPTION_LENGTH}자
                             </div>
                         </div>
@@ -135,7 +135,7 @@ const EditProfilePage = () => {
                                         </span>
                                     ))}
                                 </div>
-                                <span className="absolute right-28 -translate-y-[3.2rem] text-sm text-[var(--color--gray-60)] font-light">{keywords.length}/3개</span>
+                                <span className="absolute right-28 -translate-y-[1.5rem] text-sm text-[var(--color--gray-60)]">{keywords.length}/3개</span>
                             </div>
                             <p className="body-b1-rg text-[var(--color-gray-50)]">
                                 Tip) 본인이 주로 제작하는 상품 유형, 디자인 스타일 등을 작성해주세요!

--- a/src/pages/my-page-Reform/EditProfilePage.tsx
+++ b/src/pages/my-page-Reform/EditProfilePage.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import NicknameModal from '../../components/domain/mypage/NicknameModal';
 import Button from '../../components/common/Button/button1';
-
+import Profile from '../../assets/icons/profile.svg';
 
 const EditProfilePage = () => {
     const MAX_NICKNAME_LENGTH = 10;
@@ -10,9 +10,9 @@ const EditProfilePage = () => {
     const [description, setDescription] = useState(`- 2019년부터 리폼 공방 운영 시작 ✨\n- 6년차 스포츠 의류 리폼 전문 공방\n\n고객님들의 요청과 아쉬움을 담아, 버리지 못하고 잠들어 있던 옷에 새로운 가치와 트렌디한 디자인을 더하는 리폼을 선보이고 있어요. 1:1 맞춤 리폼 제작부터 완성 제품까지 모두 주문 가능합니다.`);
     const [keywords, setKeywords] = useState<string[]>([]);
     const [inputKeyword, setInputKeyword] = useState('');
-
-
+    const DEFAULT_PROFILE_IMAGE = Profile;
     const [isNicknameModalOpen, setIsNicknameModalOpen] = useState(false);
+    const [profileImage, setProfileImage] = useState<string | null>(null);
 
     const handleDeleteKeyword = (tag: string) => {
         setKeywords(keywords.filter(k => k !== tag));
@@ -22,15 +22,19 @@ const EditProfilePage = () => {
     return (
         <div className="w-full min-h-screen bg-white py-16">
             <div className="max-w-[75rem] mx-auto px-12 flex gap-20 items-start">
-                
                 {/* [왼쪽 영역] 프로필 이미지 - sticky 적용 */}
                 <div className="w-[12.5rem] flex-shrink-0">
                     <div className="sticky top-10">
                         <div className="w-48 h-48 rounded-full overflow-hidden border border-[var(--color-gray-50)]">
-                            <img 
-                                src="https://picsum.photos/seed/user/300/300" 
-                                alt="Profile" 
-                                className="w-full h-full object-cover" 
+                            <img
+                                src={profileImage || DEFAULT_PROFILE_IMAGE}
+                                alt="Profile"
+                                className={`object-cover w-full h-full ${
+                                !profileImage ? "scale-140" : ""
+                                }`}
+                                onError={(e) => {
+                                e.currentTarget.src = DEFAULT_PROFILE_IMAGE;
+                                }}
                             />
                         </div>
                         <label className="absolute bottom-2 right-2 w-10 h-10 bg-[#5A616A] rounded-full flex items-center justify-center border-2 border-white cursor-pointer hover:bg-gray-600 transition-colors">
@@ -38,7 +42,19 @@ const EditProfilePage = () => {
                                 <path d="M23 19a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h4l2-3h6l2 3h4a2 2 0 0 1 2 2z" />
                                 <circle cx="12" cy="13" r="4" />
                             </svg>
-                            <input type="file" className="hidden" title="사진 첨부"/>
+                            <input
+                                type="file"
+                                className='hidden'
+                                accept="image/*"
+                                title="사진 첨부"
+                                onChange={(e) => {
+                                    const file = e.target.files?.[0];
+                                    if (file) {
+                                        const imageUrl = URL.createObjectURL(file);
+                                        setProfileImage(imageUrl);
+                                    }
+                                }}
+                            />
                         </label>
                     </div>
                 </div>

--- a/src/pages/my-page-Reform/ReformerMyPage.tsx
+++ b/src/pages/my-page-Reform/ReformerMyPage.tsx
@@ -8,7 +8,6 @@ import { useSellerTabStore, type SellerTabType } from '../../stores/tabStore';
 const SELLER_TABS: readonly SellerTabType[] = [
   '프로필 관리',
   '판매 관리',
-  '수익 관리',
 ];
 
 const ReformerMyPage = () => {

--- a/src/stores/tabStore.ts
+++ b/src/stores/tabStore.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand';
 
-export type SellerTabType = '프로필 관리' | '판매 관리' | '수익 관리';
+export type SellerTabType = '프로필 관리' | '판매 관리';
 
 export interface SellerTabStore {
   activeTab: SellerTabType;


### PR DESCRIPTION
## 📌 PR 개요
> 이 PR에서 무엇을 했는지 한 줄로 요약해주세요.
리폼러 마이페이지에서 UI 수정

## 🎯 작업 내용
- 프로필 이미지 없을 시, 디폴트 이미지 추가
- 탭에서 수익관리 삭제
- 리폼러 프로필 편집 시, 글자 수 세기 글자들 위치 이동

## 🔗 관련 이슈 / 티켓
- Close #

## 🧩 작업 범위
- [x] UI
- [ ] API 연동
- [ ] 상태 관리
- [ ] 라우팅
- [ ] 공용 컴포넌트
- [x] 스타일

## 📸 스크린샷 / 영상
| Before | After |
|--------|--------|
|   
<img width="2843" height="1528" alt="image" src="https://github.com/user-attachments/assets/5b1a9637-8b39-46aa-ae9a-37a93e1db7c1" />
     |   
<img width="2846" height="1522" alt="image" src="https://github.com/user-attachments/assets/6215c951-978c-429f-9327-4d080d55942a" />
     |


## ⚠️ 리뷰어에게 요청할 사항
> 특히 봐줬으면 하는 부분을 적어주세요.
- 디폴트 이미지가 공용 assets에 있는 프로필 이미지보다 크기가 훨씬 커야해서 조건부 className을 줬습니다

## 🚨 주의사항 / 배포 전 체크
- [x] console.log 제거
- [x] 불필요한 주석 제거
- [x] 환경변수(.env) 변경 없음
- [x] 타입 에러 없음
