### PR TITLE
[FEAT]  로그인 api 구현

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -1,0 +1,13 @@
+import { api } from './axios';
+import type { LoginRequest, LoginResponse } from '../types/api/auth';
+
+
+export const loginUser = async (
+  data: LoginRequest
+): Promise<LoginResponse> => {
+  const response = await api.post<LoginResponse>(
+    '/auth/login/local',  
+    data
+  );
+  return response.data;
+};

--- a/src/components/common/Input/Input.tsx
+++ b/src/components/common/Input/Input.tsx
@@ -13,6 +13,7 @@ interface InputProps {
   type: InputType;
   value?: string;
   error?: string | null;
+  showErrorText?: boolean; 
   showPasswordToggle?: boolean;
   timerSeconds?: number | null;
   showButton?: boolean;
@@ -34,6 +35,7 @@ export default function Input({
   type,
   value: controlledValue,
   error,
+  showErrorText = true, 
   showPasswordToggle = false,
   timerSeconds = null,
   showButton = false,
@@ -203,7 +205,7 @@ export default function Input({
           </button>
         )}
       </div>
-      {error && (
+      {error && showErrorText && (
         <p className="body-b2-rg text-[var(--color-red-1)] mt-1">{error}</p>
       )}
     </div>

--- a/src/components/domain/login/Form/LoginForm.tsx
+++ b/src/components/domain/login/Form/LoginForm.tsx
@@ -1,15 +1,14 @@
 import { useState } from 'react';
-// import { useNavigate } from 'react-router-dom';
 import Input from '../../../common/Input/Input';
 import Button from '../../../common/Button/button1';
 import Checkbox from '../../../common/Checkbox/Checkbox';
-
+import { useLogin } from '../../../../hooks/domain/auth/useLogin';
 
 export default function LoginForm() {
-//   const navigate = useNavigate();
+  const { login, isLoading, error: loginApiError } = useLogin();
+  
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
-  const [loginError, setLoginError] = useState<string | null>(null);
   const [keepLoggedIn, setKeepLoggedIn] = useState(false);
  
   const validateForm = () => {
@@ -18,16 +17,10 @@ export default function LoginForm() {
 
   const handleEmailChange = (value: string) => {
     setEmail(value);
-    if (loginError) {
-      setLoginError(null);
-    }
   };
 
   const handlePasswordChange = (value: string) => {
     setPassword(value);
-    if (loginError) {
-      setLoginError(null);
-    }
   };
 
   const handleSubmit = (e: React.FormEvent) => {
@@ -35,6 +28,12 @@ export default function LoginForm() {
     if (!validateForm()) {
       return;
     }
+
+    login({
+      email,
+      password,
+      role: 'user',
+    });
   };
 
   const isFormValid = () => {
@@ -50,7 +49,8 @@ export default function LoginForm() {
           required
           placeholder="이메일을 입력해주세요."
           value={email}
-          error={loginError}
+          error={loginApiError}
+          showErrorText={false}
           onChange={handleEmailChange}
         />
 
@@ -60,7 +60,8 @@ export default function LoginForm() {
           required
           placeholder="비밀번호를 입력해주세요."
           value={password}
-          error={loginError}
+          error={loginApiError}
+          showErrorText={false}
           showPasswordToggle
           onChange={handlePasswordChange}
         />
@@ -75,18 +76,18 @@ export default function LoginForm() {
           label="로그인 유지"
           className="gap-[0.5rem]"
         />
-        <button
+        {/* <button
           type="button"
           className="body-b2-rg text-[var(--color-black)] cursor-pointer hover:underline"
         >
           아이디/비밀번호 찾기
-        </button>
+        </button> */}
       </div>
 
       <Button
         type="submit"
         variant={isFormValid() ? 'primary' : 'disabled'}
-        disabled={!isFormValid}
+        disabled={!isFormValid() || isLoading}
         className="w-full h-[4.625rem] mt-[2.4375rem] flex items-center justify-center"
       >
         로그인

--- a/src/components/layout/Header/Header.tsx
+++ b/src/components/layout/Header/Header.tsx
@@ -12,6 +12,7 @@ import repeat from '../../../assets/icons/repeat.svg';
 import xIcon from '../../../assets/icons/x.svg';
 import logo from '../../../assets/logos/logo.svg';
 import { useUserTabStore, type UserTabType } from '../../../stores/tabStore';
+import useAuthStore from '../../../stores/useAuthStore';
 
 type UserType = 'customer' | 'seller';
 
@@ -19,7 +20,10 @@ export default function Header() {
   const navigate = useNavigate();
   // 탭으로 페이지 전환하기
   const { setActiveTab } = useUserTabStore();
-    const handleTabClick = (tab: UserTabType) => {
+  // Zustand 스토어에서 로그인 상태 구독
+  const { accessToken } = useAuthStore();
+  
+  const handleTabClick = (tab: UserTabType) => {
     setActiveTab(tab);       // store에 activeTab 업데이트
     navigate('/normal-mypage'); // 페이지 이동
   }; 
@@ -98,10 +102,12 @@ export default function Header() {
 
   return (
     <header className="w-full flex flex-col">
-      <div className="body-b1-sb flex justify-end py-[0.75rem] pr-[2rem] gap-[2.75rem]">
-        <Link to="/signup" className='cursor-pointer' >회원가입</Link>
-        <Link to="/login/type" className='cursor-pointer' >로그인</Link>
-      </div>
+      {!accessToken && (
+        <div className="body-b1-sb flex justify-end py-[0.75rem] pr-[2rem] gap-[2.75rem]">
+          <Link to="/signup" className='cursor-pointer' >회원가입</Link>
+          <Link to="/login/type" className='cursor-pointer' >로그인</Link>
+        </div>
+      )}
       <div className="h-25 flex items-center  ml-[3.125rem] mr-[2rem] ">
         <Link to="/" className="w-[191px] h-[44.6px] mr-[2.19rem] ">
           <img

--- a/src/hooks/domain/auth/useLogin.ts
+++ b/src/hooks/domain/auth/useLogin.ts
@@ -1,0 +1,84 @@
+import { useMutation } from '@tanstack/react-query';
+import { useNavigate, useLocation } from 'react-router-dom';
+import { loginUser } from '../../../api/auth';
+import type { LoginRequest } from '../../../types/api/auth';
+import useAuthStore from '../../../stores/useAuthStore';
+
+interface UseLoginReturn {
+  login: (data: LoginRequest) => void;
+  isLoading: boolean;
+  error: string | null;
+}
+
+export const useLogin = (): UseLoginReturn => {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const { setAccessToken } = useAuthStore();
+
+  
+  const userRole = location.pathname.includes('reformer') ? 'reformer' : 'user';
+
+  const { mutate: loginMutation, isPending: isLoading, error: mutationError } = useMutation({
+    mutationFn: loginUser,
+    onSuccess: (data) => {
+      if (data.resultType === 'SUCCESS' && data.success) {
+       
+        if (data.success.accessToken) {
+         
+          setAccessToken(data.success.accessToken, userRole);
+        }
+     
+        navigate('/');
+      }
+    },
+    onError: (err) => {
+      console.error('로그인 실패:', err);
+    },
+  });
+
+  const login = (data: LoginRequest) => {
+    loginMutation({
+      ...data,
+      role: userRole,
+    });
+  };
+
+  const error = mutationError
+    ? (() => {
+        const axiosError = mutationError as {
+          response?: {
+            status?: number;
+            data?: {
+              message?: string;
+              error?: {
+                message?: string;
+              };
+            };
+          };
+        };
+        
+
+        if (axiosError.response?.status === 400 || axiosError.response?.status === 401) {
+          return axiosError.response?.data?.error?.message || 
+                 axiosError.response?.data?.message || 
+                 '이메일 또는 비밀번호가 올바르지 않습니다.';
+        }
+        
+
+        if (axiosError.response?.status === 500) {
+          return '서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요.';
+        }
+        
+       
+        return axiosError.response?.data?.error?.message ||
+               axiosError.response?.data?.message ||
+               '로그인에 실패했습니다. 다시 시도해주세요.';
+      })()
+    : null;
+
+  return {
+    login,
+    isLoading,
+    error,
+  };
+};

--- a/src/pages/Login/Login.tsx
+++ b/src/pages/Login/Login.tsx
@@ -31,7 +31,7 @@ const Login = () => {
           </button>
     
           <div className="body-b1-rg flex py-[1.8125rem] px-[1.875rem] gap-[1.8125rem] text-[var(--color-gray-60)]">
-            <p>이미 내폼리폼 회원이신가요?</p>
+            <p>아직 내폼리폼 회원이 아니신가요?</p>
             <Link
               to="/signup"
               className="text-[var(--color-mint-1)] underline cursor-pointer hover:scale-95 transition-all duration-300"

--- a/src/stores/useAuthStore.ts
+++ b/src/stores/useAuthStore.ts
@@ -1,31 +1,62 @@
 import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+type UserRole = 'user' | 'reformer';
 
 type User = {
   id: string;
   name: string;
   email: string;
+  role: UserRole;
 };
 
 type AuthState = {
   user: User | null;
   accessToken: string | null;
-  setAuth: (data: { user: User; accessToken: string }) => void;
+  role: UserRole | null; 
+  setAuth: (data: { user: User | null; accessToken: string }) => void;
+  setAccessToken: (accessToken: string, role?: UserRole) => void;
+  setRole: (role: UserRole) => void;
   clearAuth: () => void;
 };
 
-const useAuthStore = create<AuthState>((set) => ({
-  user: null,
-  accessToken: null,
-  setAuth: (data) =>
-    set({
-      user: data.user,
-      accessToken: data.accessToken,
-    }),
-  clearAuth: () =>
-    set({
+const useAuthStore = create<AuthState>()(
+  persist(
+    (set) => ({
       user: null,
       accessToken: null,
+      role: null,
+      setAuth: (data) =>
+        set({
+          user: data.user,
+          accessToken: data.accessToken,
+          role: data.user?.role || null,
+        }),
+      setAccessToken: (accessToken, role) =>
+        set({
+          accessToken,
+          role: role || null,
+        }),
+      setRole: (role) =>
+        set({
+          role,
+        }),
+      clearAuth: () =>
+        set({
+          user: null,
+          accessToken: null,
+          role: null,
+        }),
     }),
-}));
+    {
+      name: 'auth-storage', 
+      partialize: (state) => ({ 
+        accessToken: state.accessToken,
+        role: state.role,
+      }), 
+    }
+  )
+);
 
 export default useAuthStore;
+export type { User, UserRole };

--- a/src/types/api/auth.ts
+++ b/src/types/api/auth.ts
@@ -1,0 +1,18 @@
+// 로그인 요청 타입
+export interface LoginRequest {
+  email: string;
+  password: string;
+  role: 'user' | 'reformer';
+}
+
+// 로그인 응답 타입
+export interface LoginResponse {
+  resultType: 'SUCCESS' | 'ERROR';
+  error: null | {
+    code: string;
+    message: string;
+  };
+  success: {
+    accessToken: string;
+  } | null;
+}


### PR DESCRIPTION
## 📌 PR 개요
> 로그인 API 연동 및 인증 상태 관리 기능 구현

## 🎯 작업 내용
- 로그인 API 연동 (`/auth/login/local`)
  - 일반 사용자(`user`) 및 리폼러(`reformer`) 로그인 지원
  - URL 경로 기반 역할 자동 감지 (`/login/reformer` → reformer, `/login` → user)
  - React Query를 사용한 비동기 상태 관리
  - 에러 핸들링 (400/401, 500 에러 분기 처리)
  
- Zustand를 사용한 인증 상태 관리
  - `useAuthStore`에 `accessToken` 및 `role` 저장
  - `persist` 미들웨어로 localStorage 자동 동기화
  - 페이지 새로고침 시 로그인 상태 유지
  
- Header UI 개선
  - 로그인 상태에 따른 회원가입/로그인 링크 조건부 렌더링
  - Zustand 스토어 구독으로 실시간 상태 반영
  

```
src/
├── api/
│   └── auth.ts                    # 로그인 API 함수
├── hooks/domain/auth/
│   └── useLogin.ts                # 로그인 커스텀 훅
├── stores/
│   └── useAuthStore.ts            # 인증 상태 관리 (Zustand)
└── types/api/
    └── auth.ts                     # 로그인 관련 타입 정의
```
## 🔗 관련 이슈 / 티켓
- Close #

## 🧩 작업 범위
- [ ] UI
- [x] API 연동
- [x] 상태 관리
- [ ] 라우팅
- [ ] 공용 컴포넌트
- [ ] 스타일

## 📸 스크린샷 / 영상
| Before | After |
|--------|--------|
|        |        |


## ⚠️ 리뷰어에게 요청할 사항
> 특히 봐줬으면 하는 부분을 적어주세요.
- 

## 🚨 주의사항 / 배포 전 체크
- [x] console.log 제거
- [x] 불필요한 주석 제거
- [x] 환경변수(.env) 변경 없음
- [x] 타입 에러 없음
