### PR TITLE
[feat] 리폼러 주문제작 상세페이지 api 연동

### DIFF
--- a/src/hooks/domain/order/useReformerOrderProposalList.ts
+++ b/src/hooks/domain/order/useReformerOrderProposalList.ts
@@ -1,6 +1,7 @@
 import { useState } from 'react';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueries } from '@tanstack/react-query';
 import { getReformProposalList } from '../../../api/order/reformProposal';
+import { getProfile } from '../../../api/profile/user';
 import type {
   ReformProposalListItem,
   ReformProposalSortBy,
@@ -68,6 +69,28 @@ export const useReformerOrderProposalList = () => {
 
   const proposals: ReformProposalListItem[] =
     reformProposalListResponse?.success ?? [];
+
+  // 제안별로 닉네임(ownerName)으로 GET /profile/{id} 호출해 별점·리뷰 수 조회
+  const profileResults = useQueries({
+    queries: proposals.map((p) => ({
+      queryKey: ['profile', 'by-nickname', p.ownerName],
+      queryFn: () => getProfile(p.ownerName),
+      enabled: !!p.ownerName,
+      staleTime: 1000 * 60,
+    })),
+  });
+
+  const proposalsWithProfile: ReformProposalListItem[] = proposals.map((p, i) => {
+    const profileRes = profileResults[i]?.data;
+    const fromProfile =
+      profileRes?.resultType === 'SUCCESS' && profileRes?.success;
+    return {
+      ...p,
+      avgStar: fromProfile ? profileRes.success!.avgStar : p.avgStar,
+      reviewCount: fromProfile ? profileRes.success!.reviewCount : p.reviewCount,
+    };
+  });
+
   const hasNextPage = proposals.length >= ITEMS_PER_PAGE;
   const totalPages = currentPage + (hasNextPage ? 1 : 0);
 
@@ -97,7 +120,7 @@ export const useReformerOrderProposalList = () => {
   };
 
   return {
-    proposals,
+    proposals: proposalsWithProfile,
     isLoading,
     isError,
     currentPage,

--- a/src/pages/order/reformer/ReformerOrderPage.tsx
+++ b/src/pages/order/reformer/ReformerOrderPage.tsx
@@ -130,6 +130,7 @@ const ReformerOrderPage = () => {
                   title={item.title}
                   price={formatWon(item.price)}
                   rating={item.avgStar}
+                  ratingDecimals={1}
                   reviewCountText={`(${item.reviewCount})`}
                   nickname={item.ownerName}
                 />

--- a/src/pages/order/reformer/ReformerOrderProposalDetailPage.tsx
+++ b/src/pages/order/reformer/ReformerOrderProposalDetailPage.tsx
@@ -1,4 +1,5 @@
 import { useRef } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
 import { ImageCarousel } from '../../../components/common/product/Image';
 import ProductInfoToggle from '../../../components/common/product/detail/ProductInfoToggle';
 import ProductInfoCard from '../../../components/common/product/detail/ProductInfoCard';
@@ -7,50 +8,19 @@ import ReformerProfileDetailCard from '../../../components/common/product/detail
 import ProductReviewSection from '../../../components/common/product/detail/ProductReviewSection';
 import Button from '../../../components/common/button/Button1';
 import { useReformerOrderProposalDetail } from '../../../hooks/domain/order/useReformerOrderProposalDetail';
-import ex4 from '../../../components/common/product/eximage/ex4.jpg';
-import ex5 from '../../../components/common/product/eximage/ex5.jpg';
-import ex6 from '../../../components/common/product/eximage/ex6.jpg';
-
-interface ReviewData {
-  id: string;
-  userName: string;
-  rating: number;
-  date: string;
-  reviewText?: string;
-  image?: string;
-  profileImg?: string;
-}
-
-const getMockReviews = (): ReviewData[] => {
-  return [
-    {
-      id: '1',
-      userName: '뜨거운 아이스 아메리카노',
-      rating: 5,
-      date: '2025년 11월 20일',
-      reviewText: `제가 정말 아끼던 유니폼이 있었는데, 사이즈도 맞지 않고 낡아서 솔직히 옷장 속에만 보관되어 있었습니다. 버리기는 너무 아깝고, 그렇다고 걸어두기엔 먼지만 쌓여서 볼 때마다 마음이 아팠습니다.
-
-그러다가 '리폼'이라는 것을 알게 되었고, 이 유니폼을 짐색으로 만들기로 결정했습니다. 결과는 매우 만족스럽습니다! 등번호와 이름 부분, 그리고 팀 엠블럼이 정확히 가운데 오도록 디자인해 주셨는데, 정말 세상에 하나뿐인 굿즈가 탄생한 느낌입니다.
-
-옛날 유니폼이라 재질이 얇을까 염려했는데, 안에 덧댐 작업을 깔끔하게 해 주셔서 튼튼하고 마감도 완벽합니다. 이제는 경기장에 갈 때마다 여기에 응원봉과 간식 등 여러 가지를 챙겨서 다니는데, 그럴 때마다 유니폼을 입고 뛰던 시절의 추억이 새록새록 떠오릅니다. 정말 돈이 아깝지 않은 리폼이었습니다`,
-      image: '/wsh1.jpg',
-    },
-    {
-      id: '2',
-      userName: '차가운 핫초코',
-      rating: 5,
-      date: '2025년 11월 15일',
-      reviewText: '정말 만족스러운 리폼이었습니다. 빠른 배송과 깔끔한 마감이 인상적이에요!',
-    },
-  ];
-};
 
 const ITEMS_PER_PAGE = 5;
 
 const ReformerOrderProposalDetailPage = () => {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
   const {
-    id,
     proposalDetail,
+    profile,
+    reviews,
+    photoReviewCount,
+    reviewPhotos,
+    reviewsAvgStar,
     isLoading,
     isError,
     isLiked,
@@ -66,10 +36,7 @@ const ReformerOrderProposalDetailPage = () => {
     formattedEstimatedPeriod,
     handleShare,
     handlePageChange,
-    navigate,
   } = useReformerOrderProposalDetail();
-
-  const reviews = getMockReviews();
   const infoSectionRef = useRef<HTMLDivElement>(null);
   const reformerSectionRef = useRef<HTMLDivElement>(null);
   const reviewSectionRef = useRef<HTMLDivElement>(null);
@@ -92,15 +59,24 @@ const ReformerOrderProposalDetailPage = () => {
   }
 
   if (isLoading) {
-    return <div className="p-8">불러오는 중...</div>;
+    return (
+      <div className="px-4 md:px-27 pt-15">
+        <p className="body-b1-rg text-[var(--color-gray-60)]">불러오는 중...</p>
+      </div>
+    );
   }
 
   if (isError || !proposalDetail) {
-    return <div className="p-8">제안서를 불러오지 못했어요. 잠시 후 다시 시도해주세요.</div>;
+    return (
+      <div className="px-4 md:px-27 pt-15">
+        <p className="body-b1-rg text-[var(--color-gray-60)]">
+          제안서를 불러오지 못했어요.
+        </p>
+      </div>
+    );
   }
 
-  const { title, content, ownerName, ownerProfile, isOwner, ownerId } = proposalDetail;
-  const isMyProposal = isOwner;
+  const isMyProposal = proposalDetail.isOwner;
 
   const handleRequest = () => {};
 
@@ -111,6 +87,9 @@ const ReformerOrderProposalDetailPage = () => {
   const handleMorePhotoReviewsClick = () => {
     // 사진 후기 더보기 로직
   };
+
+  const firstImage = imageUrls[0];
+  const additionalImages = imageUrls.length > 1 ? imageUrls.slice(1) : [];
 
   return (
     <div className="bg-white">
@@ -125,17 +104,17 @@ const ReformerOrderProposalDetailPage = () => {
           {/* 오른쪽: 제안 상세 정보 */}
           <div className="flex-1">
             <ProductInfoCard
-              title={title}
+              title={proposalDetail.title}
               price={formattedPrice}
-              rating={4.94}
-              recentRating={4.92}
+              rating={profile?.avgStar ?? 0}
+              recentRating={profile?.avgStarRecent3m}
               shippingFee={formattedShippingFee}
               estimatedPeriod={formattedEstimatedPeriod}
               reformer={{
-                id: proposalDetail.reformProposalId,
-                name: ownerName,
-                profileImg: ownerProfile,
-                description: content,
+                id: profile?.ownerId ?? proposalDetail.ownerId ?? proposalDetail.reformProposalId,
+                name: profile?.nickname ?? proposalDetail.ownerName,
+                profileImg: profile?.profilePhoto ?? proposalDetail.ownerProfile,
+                description: proposalDetail.content,
               }}
               isLiked={isLiked}
               onLikeClick={handleLike}
@@ -171,36 +150,45 @@ const ReformerOrderProposalDetailPage = () => {
 
         {/* 상품 정보 */}
         <div ref={infoSectionRef} data-tab="info" className="mb-16 scroll-mt-24">
-          <ProductInfoToggle firstImage={ex4} additionalImages={[ex5, ex6]} />
+          <ProductInfoToggle
+            firstImage={firstImage}
+            additionalImages={additionalImages}
+          />
         </div>
 
         {/* 리폼러 정보 */}
         <div ref={reformerSectionRef} className="mb-16 flex justify-center scroll-mt-24">
           <div className="max-w-[63.75rem] w-full">
             <ReformerProfileDetailCard
-              name={ownerName}
-              rating={4.97}
-              orderCount={415}
-              reviewCount={271}
-              profileImg={ownerProfile}
-              onFeedClick={() => ownerId && navigate(`/profile/${ownerId}`)}
+              name={profile?.nickname ?? proposalDetail.ownerName}
+              rating={profile?.avgStar ?? 0}
+              orderCount={profile?.totalSaleCount ?? 0}
+              reviewCount={profile?.reviewCount ?? 0}
+              profileImg={profile?.profilePhoto ?? proposalDetail.ownerProfile}
+              bio={profile?.bio}
+              onFeedClick={() => {
+                const ownerId = profile?.ownerId ?? proposalDetail.ownerId;
+                if (ownerId) navigate(`/profile/${ownerId}`);
+                else navigate('/profile');
+              }}
             />
           </div>
         </div>
 
         {/* 상품 후기 */}
         <div ref={reviewSectionRef} className="scroll-mt-24">
-        <ProductReviewSection
-          rating={4.94}
-          photoReviewCount={182}
-          reviews={reviews}
-          currentPage={currentPage}
-          itemsPerPage={ITEMS_PER_PAGE}
-          sortBy={sortBy}
-          onSortChange={setSortBy}
-          onPageChange={handlePageChange}
-          onMorePhotoReviewsClick={handleMorePhotoReviewsClick}
-        />
+          <ProductReviewSection
+            rating={reviewsAvgStar ?? profile?.avgStar ?? 0}
+            photoReviewCount={photoReviewCount}
+            reviews={reviews}
+            currentPage={currentPage}
+            itemsPerPage={ITEMS_PER_PAGE}
+            sortBy={sortBy}
+            onSortChange={setSortBy}
+            onPageChange={handlePageChange}
+            onMorePhotoReviewsClick={handleMorePhotoReviewsClick}
+            photoReviewImages={reviewPhotos}
+          />
         </div>
       </div>
     </div>

--- a/src/types/api/order/reformProposal.ts
+++ b/src/types/api/order/reformProposal.ts
@@ -37,6 +37,20 @@ export interface ReformProposalImage {
   photo_order: number;
 }
 
+/** GET /reform/proposal/{id} 응답의 profile 객체 */
+export interface ReformProposalDetailProfile {
+  bio: string;
+  keywords: string[];
+  /** API 응답에 toatalSaleCount 오타 존재 가능 */
+  totalSaleCount?: number;
+  toatalSaleCount?: number;
+  reviewCount: number;
+  avgStarRecent3m: number;
+  avgStar: number;
+  ownerProfile: string;
+  ownerName: string;
+}
+
 export interface ReformProposalDetail {
   isOwner: boolean;
   /** 게시글 작성자 ID (프론트엔드 fallback용, API에서 제공 시 사용) */
@@ -50,6 +64,8 @@ export interface ReformProposalDetail {
   ownerName: string;
   ownerProfile: string;
   images: ReformProposalImage[];
+  /** 제안서 상세 API에 포함된 리폼러 프로필 (별점, 후기수 등) */
+  profile?: ReformProposalDetailProfile;
 }
 
 export interface GetReformProposalDetailResponse {


### PR DESCRIPTION
## 📌 PR 개요
> 리폼러 주문제작 상세페이지 api 연동

## 🎯 작업 내용
- 리폼러 주문제작 상세페이지 api 연동
- 제안글 카드 별점 연동
- 제안글 상세페이지 별점,후기수,프로필,후기 연동

## 🔗 관련 이슈 / 티켓
- Close #

## 🧩 작업 범위
- [ ] UI
- [x] API 연동
- [ ] 상태 관리
- [ ] 라우팅
- [ ] 공용 컴포넌트
- [ ] 스타일

## 📸 스크린샷 / 영상
| Before | After |
|--------|--------|
|        |        |


## ⚠️ 리뷰어에게 요청할 사항
> 특히 봐줬으면 하는 부분을 적어주세요.
- 

## 🚨 주의사항 / 배포 전 체크
- [x] console.log 제거
- [x] 불필요한 주석 제거
- [x] 환경변수(.env) 변경 없음
- [x] 타입 에러 없음
