### PR TITLE
[FIX] 렌딩 페이지 네비게이션 수정 & 푸터 네비게이션 추가

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -65,6 +65,21 @@ function App() {
       <ScrollToTop />
       <Routes>
 
+
+      <Route
+      element={
+        <Layout
+          showHeader={false}
+          showNavbar={false}
+          showFooter={true}
+          footerVariant="dark"
+        />
+      }
+      >
+       <Route path="/" element={<LandingPage />} />
+
+      </Route>
+
       <Route
         element={
           <Layout
@@ -76,7 +91,7 @@ function App() {
         }
       >
         {/* 홈 페이지 */}
-        <Route path="/" element={<Home />} />
+        <Route path="/home" element={<Home />} />
       </Route>
 
       <Route
@@ -156,20 +171,6 @@ function App() {
         <Route path="/order/requests/create" element={<OrderRequestCreatePage />} />
         <Route path="/order/requests/:id/edit" element={<OrderRequestEditPage />} />
         <Route path="/reformer/order/requests/:id/estimate" element={<ReformerOrderEstimateCreatePage />} />
-      </Route>
-
-      <Route
-      element={
-        <Layout
-          showHeader={false}
-          showNavbar={false}
-          showFooter={true}
-          footerVariant="dark"
-        />
-      }
-      >
-       <Route path="/landing" element={<LandingPage />} />
-
       </Route>
       
       <Route

--- a/src/components/layout/footer/Footer.tsx
+++ b/src/components/layout/footer/Footer.tsx
@@ -1,3 +1,4 @@
+import { useNavigate } from 'react-router-dom';
 import logo from '../../../assets/logos/logo.svg';
 
 interface FooterProps {
@@ -5,6 +6,7 @@ interface FooterProps {
 }
 
 const Footer = ({ variant = 'dark' }: FooterProps) => {
+  const navigate = useNavigate();
   const isDark = variant === 'dark';
 
   return (
@@ -60,7 +62,7 @@ const Footer = ({ variant = 'dark' }: FooterProps) => {
           </div>
         </div>
       </div>
-      <div className="w-[514px] h-[63px] flex gap-[3.5rem] mt-[2.5rem]">
+      <div className="h-[63px] flex gap-[3.5rem] mt-[2.5rem]">
         <div className="flex flex-col gap-[0.375rem]">
           <p className="body-b0-sb">내폼리폼 고객센터</p>
           <p className="body-b1-sb text-[var(--color-gray-40)]">
@@ -69,10 +71,11 @@ const Footer = ({ variant = 'dark' }: FooterProps) => {
         </div>
         <div className="flex flex-col gap-[0.375rem]">
           <p className="body-b0-sb">서비스</p>
-          <ul className="body-b1-sb flex gap-[0.875rem] list-none text-[var(--color-gray-40)]">
-            <li>리폼마켓</li>
-            <li>리폼 요청</li>
-            <li>리폼 제안</li>
+          <ul className="body-b1-sb flex gap-[0.875rem] list-none text-[var(--color-gray-40)] cursor-pointer">
+            <li onClick={() => navigate('/market')}>마켓</li>
+            <li onClick={() => navigate('/order')}>주문제작</li>
+            <li onClick={() => navigate('/reformer-search')}>리폼러 찾기</li>
+            <li onClick={() => navigate('/')}>서비스 소개</li>
           </ul>
         </div>
       </div>

--- a/src/components/layout/header/Header.tsx
+++ b/src/components/layout/header/Header.tsx
@@ -252,16 +252,7 @@ export default function Header() {
                     >
                       판매 관리
                     </button>
-                    <button
-                      onClick={() => {
-                        setSellerActiveTab('수익 관리'); // 탭 상태 업데이트
-                        navigate('/reformer-mypage'); // 해당 페이지로 이동
-                        setIsProfileOpen(false); // 드롭다운 닫기
-                      }}
-                      className="body-b1-md w-full text-left px-2 py-[1.125rem] text-[var(--color-gray-50)] hover:text-[var(--color-black)]"
-                    >
-                      수익 관리
-                    </button>
+                    
                   </div>
                 </div>
                 <button

--- a/src/components/layout/header/Header.tsx
+++ b/src/components/layout/header/Header.tsx
@@ -215,7 +215,8 @@ export default function Header() {
           <Link to="/cart" className="cursor-pointer">
             <img src={shoppingCart} alt="shopping cart" />
           </Link>
-
+          
+          {accessToken && (
           <div className="relative" ref={profileRef}>
             <button
               className="cursor-pointer"
@@ -297,6 +298,7 @@ export default function Header() {
             )}
 
           </div>
+          )}
         </div>
       </div>
     </header>

--- a/src/components/layout/header/HeaderNav.tsx
+++ b/src/components/layout/header/HeaderNav.tsx
@@ -7,7 +7,7 @@ export default function HeaderNav() {
   const { role } = useAuthStore();
 
   const navItems = [
-    { label: '홈', path: '/' }, //임시 경로
+    { label: '홈', path: '/home' }, //임시 경로
     { label: '마켓', path: '/market' }, //임시 경로
     { label: '주문제작', path: '/order' }, 
     { label: '리폼러 찾기', path: '/reformer-search' },

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -105,7 +105,7 @@ const LandingPage = () => {
           <p className="heading-h2-bd">리폼하고 싶은데</p>
           <p className="heading-h2-bd">누구에게 맡길지는 모르겠다면?</p>
           <img src={logo} alt="logo" className="mt-10 w-140 h-140 brightness-0 -my-4 object-contain" style={{ maxHeight: '200px' }} />
-          <button type="button" onClick={() => navigate('/')} className="mt-20 heading-h5-sb bg-black text-white px-16 py-4 rounded-full flex items-center gap-2 cursor-pointer">
+          <button type="button" onClick={() => navigate('/home')} className="mt-20 heading-h5-sb bg-black text-white px-16 py-4 rounded-full flex items-center gap-2 cursor-pointer">
             자세히 둘러보기
 
             <img src={rightIcon} alt="right" className="w-10 h-10 brightness-0 invert pb-1" />

--- a/src/pages/my-page-Reform/ReformerMyPage.tsx
+++ b/src/pages/my-page-Reform/ReformerMyPage.tsx
@@ -10,7 +10,6 @@ import { getMyReformerInfo } from '../../api/profile/user';
 const SELLER_TABS: readonly SellerTabType[] = [
   '프로필 관리',
   '판매 관리',
-  '수익 관리',
 ];
 
 const ReformerMyPage = () => {

--- a/src/stores/tabStore.ts
+++ b/src/stores/tabStore.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand';
 
-export type SellerTabType = '프로필 관리' | '판매 관리' | '수익 관리';
+export type SellerTabType = '프로필 관리' | '판매 관리';
 
 export interface SellerTabStore {
   activeTab: SellerTabType;


### PR DESCRIPTION
## 📌 PR 개요
> 렌딩 페이지 네비게이션 수정 & 푸터 네비게이션 추가

## 🎯 작업 내용
- 기존 디폴트 경로 홈에서 랜딩 페이지로 수정
- 푸터 서비스별로 네비게이션 경로 설정
   - 마켓 - /market
   - 주문제작 - /order
   - 리폼러 찾기 - /reformer-search
   - 서비스 소개 - /

## 🔗 관련 이슈 / 티켓
- Close #

## 🧩 작업 범위
- [x] UI
- [ ] API 연동
- [ ] 상태 관리
- [x] 라우팅
- [x] 공용 컴포넌트
- [ ] 스타일

## 📸 스크린샷 / 영상
| Before | After |
|--------|--------|
|        |        |


## ⚠️ 리뷰어에게 요청할 사항
> 특히 봐줬으면 하는 부분을 적어주세요.
- 

## 🚨 주의사항 / 배포 전 체크
- [x] console.log 제거
- [x] 불필요한 주석 제거
- [x] 환경변수(.env) 변경 없음
- [x] 타입 에러 없음
