### PR TITLE
[FEAT] 마켓 상세 페이지 리폼러 정보 & 리뷰 목록 api 연동

### DIFF
--- a/src/api/market/market.ts
+++ b/src/api/market/market.ts
@@ -32,8 +32,6 @@ export const getMarketProductList = async (
 export const getMarketProductDetail = async (
     params: GetMarketProductDetailParams
 ): Promise<GetMarketProductDetailResponse> => {
-    const response = await api.get<GetMarketProductDetailResponse>('/market/', {
-        params,
-    });
+    const response = await api.get<GetMarketProductDetailResponse>(`/market/${params.item_id}`);
     return response.data;
 };

--- a/src/api/market/market.ts
+++ b/src/api/market/market.ts
@@ -4,7 +4,11 @@ import type {
     GetMarketProductListParams,
     GetMarketProductListResponse,
     GetMarketProductDetailParams,
-    GetMarketProductDetailResponse
+    GetMarketProductDetailResponse,
+    MarketProductPhotoReviewRequest,
+    MarketProductPhotoReviewResponse,
+    MarketProductReviewListRequest,
+    MarketProductReviewListResponse
 } from '../../types/api/market/market';
 
 
@@ -28,10 +32,38 @@ export const getMarketProductList = async (
     });
     return response.data;
 };
-
+// 마켓 상품 상세 조회
 export const getMarketProductDetail = async (
     params: GetMarketProductDetailParams
 ): Promise<GetMarketProductDetailResponse> => {
     const response = await api.get<GetMarketProductDetailResponse>(`/market/${params.item_id}`);
+    return response.data;
+};
+
+// 마켓 상품 리뷰 목록 조회
+export const getMarketProductReviewList = async (
+    params: MarketProductReviewListRequest
+): Promise<MarketProductReviewListResponse> => {
+    const response = await api.get<MarketProductReviewListResponse>(`/market/${params.itemId}/reviews`, {
+        params: {
+            page: params.page,
+            limit: params.limit,
+            sort: params.sort,
+        },
+    });
+    return response.data;
+};
+
+
+// 마켓 상품 사진 후기 조회
+export const getMarketProductPhotoReview = async (
+    params: MarketProductPhotoReviewRequest
+): Promise<MarketProductPhotoReviewResponse> => {
+    const response = await api.get<MarketProductPhotoReviewResponse>(`/market/${params.itemId}/reviews/photos`, {
+        params: {
+            offset: params.offset,
+            limit: params.limit,
+        },
+    });
     return response.data;
 };

--- a/src/hooks/domain/market/useMarketProductList.ts
+++ b/src/hooks/domain/market/useMarketProductList.ts
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { getMarketProductList } from '../../../api/market/market';
-import type { GetMarketProductDetailResponse } from '../../../types/api/market/market';
+import type { MarketProductItem } from '../../../types/api/market/market';
 import { getMarketProductDetail } from '../../../api/market/market'; 
 import { getMarketProductPhotoReview } from '../../../api/market/market';
 import { getMarketProductReviewList } from '../../../api/market/market';
@@ -38,7 +38,7 @@ export const useMarketProductList = () => {
     staleTime: 1000 * 30,
   });
 
-  const products: GetMarketProductDetailResponse[] = productListResponse?.success.items ?? [];  
+  const products: MarketProductItem[] = productListResponse?.success.items ?? [];  
   const hasNextPage = products.length >= 15;
   const totalPages = currentPage + (hasNextPage ? 1 : 0);
 

--- a/src/hooks/domain/market/useMarketProductList.ts
+++ b/src/hooks/domain/market/useMarketProductList.ts
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { getMarketProductList } from '../../../api/market/market';
-import type { MarketProductItem } from '../../../types/api/market/market';
+import type { GetMarketProductDetailResponse } from '../../../types/api/market/market';
 import { getMarketProductDetail } from '../../../api/market/market'; 
 
 
@@ -37,7 +37,7 @@ export const useMarketProductList = () => {
     staleTime: 1000 * 30,
   });
 
-  const products: MarketProductItem[] = productListResponse?.success.items ?? [];
+  const products: GetMarketProductDetailResponse[] = productListResponse?.success.items ?? [];
   const hasNextPage = products.length >= 15;
   const totalPages = currentPage + (hasNextPage ? 1 : 0);
 
@@ -84,16 +84,15 @@ export const useMarketProductDetail = (itemId: string | undefined) => {
   const { data: productDetailResponse } = useQuery({
     queryKey: ['market-product-detail', itemId],
     queryFn: async () => {
-
-       const data = await getMarketProductDetail({ item_id: itemId ?? '' });
-       return data;
+   
+      const data = await getMarketProductDetail({ item_id: itemId ?? '' });
+      return data;
     },
     enabled: !!itemId,
     staleTime: 1000 * 30,
-    retry: 1,
   });
   
   return {
-    productDetailResponse,
+    productDetailResponse
   };
 };

--- a/src/hooks/domain/market/useMarketProductList.ts
+++ b/src/hooks/domain/market/useMarketProductList.ts
@@ -3,7 +3,8 @@ import { useQuery } from '@tanstack/react-query';
 import { getMarketProductList } from '../../../api/market/market';
 import type { GetMarketProductDetailResponse } from '../../../types/api/market/market';
 import { getMarketProductDetail } from '../../../api/market/market'; 
-
+import { getMarketProductPhotoReview } from '../../../api/market/market';
+import { getMarketProductReviewList } from '../../../api/market/market';
 
 export type MarketCategorySelection = {
   categoryTitle: string;
@@ -37,7 +38,7 @@ export const useMarketProductList = () => {
     staleTime: 1000 * 30,
   });
 
-  const products: GetMarketProductDetailResponse[] = productListResponse?.success.items ?? [];
+  const products: GetMarketProductDetailResponse[] = productListResponse?.success.items ?? [];  
   const hasNextPage = products.length >= 15;
   const totalPages = currentPage + (hasNextPage ? 1 : 0);
 
@@ -94,5 +95,46 @@ export const useMarketProductDetail = (itemId: string | undefined) => {
   
   return {
     productDetailResponse
+  };
+};
+
+export const useMarketProductPhotoReview = (itemId: string | undefined) => {
+  const { data: photoReviewResponse } = useQuery({
+    queryKey: ['market-product-photo-review', itemId],
+    queryFn: async () => {
+      const data = await getMarketProductPhotoReview({ itemId: itemId ?? '', offset: 0, limit: 15 });
+      return data;
+    },
+    enabled: !!itemId,
+    staleTime: 1000 * 30,
+  });
+  
+  return {
+    photoReviewResponse
+  };
+};
+
+export const useMarketProductReviewList = (
+  itemId: string | undefined,
+  page: number = 1,
+  sort: 'latest' | 'star_high' | 'star_low' = 'latest'
+) => {
+  const { data: reviewListResponse } = useQuery({
+    queryKey: ['market-product-review-list', itemId, page, sort],
+    queryFn: async () => {
+      const data = await getMarketProductReviewList({ 
+        itemId: itemId ?? '', 
+        page, 
+        limit: 15, 
+        sort 
+      });
+      return data;
+    },
+    enabled: !!itemId,
+    staleTime: 1000 * 30,
+  });
+  
+  return {
+    reviewListResponse
   };
 };

--- a/src/pages/market/MarketProductDetailPage.tsx
+++ b/src/pages/market/MarketProductDetailPage.tsx
@@ -539,7 +539,7 @@ const MarketProductDetailPage = () => {
                 <div className="flex-1 border-t border-b border-[var(--color-line-gray-40)] py-[1.125rem] flex flex-col items-center gap-[0.5rem]">
                   <span className="body-b0-rg text-[var(--color-gray-50)]">후기</span>
                   <span className="heading-h4-bd text-[1.875rem] text-[var(--color-black)]">
-                    {review_count}개
+                    {product.reformer.review_count}개
                   </span>
                 </div>
                

--- a/src/pages/market/MarketProductDetailPage.tsx
+++ b/src/pages/market/MarketProductDetailPage.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef, useMemo } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
+import xIcon from '../../assets/icons/x.svg';
 import { ImageCarousel } from '../../components/common/product/Image';
 import OptionQuantity from '../../components/common/product/option/option-quantity-button/OptionQuantity';  
 import ProductInfoToggle from '../../components/common/product/detail/ProductInfoToggle';
@@ -292,8 +293,8 @@ const MarketProductDetailPage = () => {
           {/* 선택된 옵션이 있을 때만 표시 */}
           {Object.keys(selectedOptions).length > 0 && (
             <div className="bg-[var(--color-gray-20)] p-[0.625rem] flex flex-col gap-[1.75rem] mt-[2.25rem]">
-              <div className='flex flex-col gap-[0.5rem]'>
-                <span className="body-b1-rg px-[0.625rem]">
+              <div className=' flex items-center justify-between gap-[0.5rem]'>
+                <span className="body-b1-rg px-[0.625rem] flex items-center justify-between w-full">
                   {product.option_groups
                     .map((group) => {
                       const selectedOptionId = selectedOptions[group.option_group_id];
@@ -306,11 +307,14 @@ const MarketProductDetailPage = () => {
                       return '';
                     })
                     .filter(Boolean)
-                    .join(', ')}
+                    .join(', ')}                  
+                      <img src={xIcon} alt="x" className="w-10 h-10 cursor-pointer" onClick={() => setSelectedOptions({})} 
+                      />
+                 
                 </span>
               </div>
-              <div className="flex items-center justify-between">
-                
+
+              <div className="flex items-center justify-between">              
                 <OptionQuantity
                   quantity={quantity}
                   onIncrease={() => setQuantity(quantity + 1)}
@@ -319,7 +323,7 @@ const MarketProductDetailPage = () => {
                
                 <p className="body-b0-bd px-[0.625rem]">
                   {formatPrice((basePrice + optionPrice) * quantity)}원
-                  {optionPrice > 0 && ` (옵션 +${formatPrice(optionPrice)}원)`}
+                 
                 </p>
               </div>
             </div>
@@ -335,6 +339,7 @@ const MarketProductDetailPage = () => {
             </div>
             
             <div className="flex flex-col gap-[0.625rem]">
+              
               <div className="flex gap-[0.625rem]">
                 <Button
                   variant="white"
@@ -350,15 +355,31 @@ const MarketProductDetailPage = () => {
                   />
                   <span className="body-b0-bd text-[1.25rem]">찜하기</span>
                 </Button>
-                <button className="flex-1 h-[4.625rem] bg-white border border-[var(--color-line-gray-40)] rounded-[0.625rem] flex items-center justify-center gap-[0.625rem]">
+                <Button
+                  variant="white"
+                  onClick={() => {
+                    navigate(`/market/product/${id}/cart`);
+                  }}
+                  className="flex items-center justify-center gap-2 flex-1 h-[4.625rem]"
+                >
                   <img src={cartIcon} alt="장바구니" className="w-10 h-10" />
                   <span className="body-b0-bd text-[1.25rem]">장바구니</span>
-                </button>
-                <button className="flex-1 h-[4.625rem] bg-white border border-[var(--color-line-gray-40)] rounded-[0.625rem] flex items-center justify-center gap-[0.625rem]">
-                  <img src={chatIcon} alt="문의하기" className="w-10 h-10" />
+                </Button>
+                 
+               <Button
+                  variant="white"
+                  onClick={() => {
+                    navigate(`/market/product/${id}/chat`);
+                  }}
+                  className="flex items-center justify-center gap-2 flex-1 h-[4.625rem]"
+                >
+                  <img src={chatIcon} alt="채팅" className="w-10 h-10" />
                   <span className="body-b0-bd text-[1.25rem]">문의하기</span>
-                </button>
+                </Button>
+                  
+               
               </div>
+
               <button 
                 onClick={() => {
                   const allOptionsSelected = optionGroups.every(group => 
@@ -458,15 +479,13 @@ const MarketProductDetailPage = () => {
 
         <div ref={reformerRef} id="reformer-info" className="scroll-mt-[100px] mx-[7.125rem] pt-[6.25rem]">
           <div className="flex gap-[3.3125rem] items-start">
-            <div className="w-[8.4375rem] h-[8.4375rem] rounded-full bg-[var(--color-gray-20)] flex items-center justify-center">
-              <span className="heading-h4-bd text-[2rem] text-[var(--color-gray-60)]">
-                {owner_nickname.charAt(0)}
-              </span>
+            <div className="w-[8.4375rem] h-[8.4375rem] rounded-full bg-[var(--color-gray-20)] flex items-center justify-center">             
+                 <img src={product.reformer.profile_image} alt="profile" className="w-full h-full object-cover rounded-full" />
             </div>
             <div className="flex-1 flex flex-col gap-[2.625rem]">
               <div className="flex flex-col gap-[0.75rem]">
                 <h2 className="heading-h4-bd text-[1.875rem] text-[var(--color-black)]">
-                  {owner_nickname}
+                  {product.reformer.nickname}
                 </h2>
                 <div className="flex items-center gap-[0.625rem]">
                   <div className="flex gap-[0.375rem]">
@@ -480,7 +499,7 @@ const MarketProductDetailPage = () => {
                     ))}
                   </div>
                   <span className="body-b1-sb text-[var(--color-black)]">
-                    {star}
+                    {product.reformer.star}
                   </span>
                 </div>
               </div>
@@ -497,8 +516,20 @@ const MarketProductDetailPage = () => {
                     {review_count}개
                   </span>
                 </div>
+               
               </div>
-              <button className="w-full h-[4.625rem] border border-[var(--color-mint-1)] rounded-[0.625rem] flex items-center justify-center">
+              <div className="flex-1 flex flex-col gap-[0.5rem]">
+                  <ol className="flex flex-col gap-[0.5rem]">
+                    <li className="body-b1-rg text-[var(--color-gray-60)]">
+                      - {product.content} 
+                    </li>
+                  </ol>
+                  
+                  </div>
+              <button                
+                className="w-full h-[4.625rem] border border-[var(--color-mint-1)] rounded-[0.625rem] flex items-center justify-center cursor-pointer hover:opacity-90 transition-opacity"
+                onClick={() => navigate(`/profile/${product.reformer.owner_id}`)}
+              >
                 <span className="body-b0-bd text-[1.25rem] text-[var(--color-mint-1)]">
                   피드 보러가기
                 </span>

--- a/src/pages/market/MarketProductDetailPage.tsx
+++ b/src/pages/market/MarketProductDetailPage.tsx
@@ -547,7 +547,7 @@ const MarketProductDetailPage = () => {
               <div className="flex-1 flex flex-col gap-[0.5rem]">
                   <ol className="flex flex-col gap-[0.5rem]">
                     <li className="body-b1-rg text-[var(--color-gray-60)]">
-                      - {product.content} 
+                      {product.reformer.bio}
                     </li>
                   </ol>
                   

--- a/src/types/api/market/market.ts
+++ b/src/types/api/market/market.ts
@@ -95,6 +95,7 @@ export interface GetMarketProductDetailResponse {
         reformer: {
             nickname: string;
             order_count: number;
+            review_count: number;
             owner_id: string;
             profile_image: string;
             star: number;

--- a/src/types/api/market/market.ts
+++ b/src/types/api/market/market.ts
@@ -99,6 +99,7 @@ export interface GetMarketProductDetailResponse {
             profile_image: string;
             star: number;
             star_recent_3m: number;
+            bio: string;
         };     
     };
 }

--- a/src/types/api/market/market.ts
+++ b/src/types/api/market/market.ts
@@ -68,9 +68,42 @@ export interface GetMarketProductDetailResponse {
         message: string;
     };  
     success: {
-        item: MarketProductItem[];
+        category: {
+            major: string;
+            sub: string;
+        };
+        
+        title: string;
+        content: string;
+        delivery: number;
+        delivery_info: string;
+        images: string[];
+        item_id: string;
+        price: number;
+        is_wished: boolean;
+        option_groups: {
+            option_group_id: string;
+            name: string;
+            option_items: {
+                option_item_id: string;
+                name: string;
+                extra_price: number;
+                quantity: number;
+                is_sold_out: boolean;
+            }[];
+        }[];
+        reformer: {
+            nickname: string;
+            order_count: number;
+            owner_id: string;
+            profile_image: string;
+            star: number;
+            star_recent_3m: number;
+        };     
     };
 }
+
+
 
 
 

--- a/src/types/api/market/market.ts
+++ b/src/types/api/market/market.ts
@@ -102,6 +102,61 @@ export interface GetMarketProductDetailResponse {
         };     
     };
 }
+// 상품 리뷰 목록 조회 
+export interface MarketProductReviewListRequest {
+    itemId: string;
+    page: number;
+    limit: number;
+    sort: 'latest' | 'star_high' | 'star_low';
+}
+export interface MarketProductReviewListResponse {
+
+    success: {
+        reviews: {
+            review_id: string;
+            user_profile_image: string;
+            user_nickname: string;
+            star: number;
+            created_at: string;
+            content: string;
+            product_thumbnail: string;
+            photos: string[];
+        }[];
+        total_count: number;
+        avg_star: number;
+        page: number;
+        limit: number;
+        total_pages: number;
+        has_next_page: boolean;
+        has_prev_page: boolean;
+    };
+}
+   
+
+
+
+
+//마켓 상품 사진 후기 조회
+export interface MarketProductPhotoReviewRequest {
+    itemId: string;
+    offset: number;
+    limit: number;
+}
+
+export interface MarketProductPhotoReviewResponse {  
+    success: {
+        photos: {
+            photo_index: number;
+            review_id: string;
+            photo_url: string;
+            photo_order: number;
+        }[];
+        has_more: boolean;
+        offset: number;
+        limit: number;
+        total_count: number;     
+    };
+}
 
 
 


### PR DESCRIPTION
## 📌 PR 개요
> 마켓 상세 페이지 리폼러 정보 & 리뷰 목록 api 연동

## 🎯 작업 내용
- 상품 상세 조회, 상품 리뷰 조회, 상품 사진 목록 조회 api 추가
- 

## 🔗 관련 이슈 / 티켓
- Close #

## 🧩 작업 범위
- [ ] UI
- [x] API 연동
- [ ] 상태 관리
- [ ] 라우팅
- [ ] 공용 컴포넌트
- [ ] 스타일

## 📸 스크린샷 / 영상
| Before | After |
|--------|--------|
|        |        |


## ⚠️ 리뷰어에게 요청할 사항
> 특히 봐줬으면 하는 부분을 적어주세요.
- 

## 🚨 주의사항 / 배포 전 체크
- [x] console.log 제거
- [x] 불필요한 주석 제거
- [x] 환경변수(.env) 변경 없음
- [x] 타입 에러 없음
