### PR TITLE
[FEAT] 마켓 상세 페이지 결제 api 추가

### DIFF
--- a/src/api/market/market.ts
+++ b/src/api/market/market.ts
@@ -32,8 +32,6 @@ export const getMarketProductList = async (
 export const getMarketProductDetail = async (
     params: GetMarketProductDetailParams
 ): Promise<GetMarketProductDetailResponse> => {
-    const response = await api.get<GetMarketProductDetailResponse>('/market/', {
-        params,
-    });
+    const response = await api.get<GetMarketProductDetailResponse>(`/market/${params.item_id}`);
     return response.data;
 };

--- a/src/api/market/market.ts
+++ b/src/api/market/market.ts
@@ -4,7 +4,11 @@ import type {
     GetMarketProductListParams,
     GetMarketProductListResponse,
     GetMarketProductDetailParams,
-    GetMarketProductDetailResponse
+    GetMarketProductDetailResponse,
+    MarketProductPhotoReviewRequest,
+    MarketProductPhotoReviewResponse,
+    MarketProductReviewListRequest,
+    MarketProductReviewListResponse
 } from '../../types/api/market/market';
 
 
@@ -28,10 +32,38 @@ export const getMarketProductList = async (
     });
     return response.data;
 };
-
+// 마켓 상품 상세 조회
 export const getMarketProductDetail = async (
     params: GetMarketProductDetailParams
 ): Promise<GetMarketProductDetailResponse> => {
     const response = await api.get<GetMarketProductDetailResponse>(`/market/${params.item_id}`);
+    return response.data;
+};
+
+// 마켓 상품 리뷰 목록 조회
+export const getMarketProductReviewList = async (
+    params: MarketProductReviewListRequest
+): Promise<MarketProductReviewListResponse> => {
+    const response = await api.get<MarketProductReviewListResponse>(`/market/${params.itemId}/reviews`, {
+        params: {
+            page: params.page,
+            limit: params.limit,
+            sort: params.sort,
+        },
+    });
+    return response.data;
+};
+
+
+// 마켓 상품 사진 후기 조회
+export const getMarketProductPhotoReview = async (
+    params: MarketProductPhotoReviewRequest
+): Promise<MarketProductPhotoReviewResponse> => {
+    const response = await api.get<MarketProductPhotoReviewResponse>(`/market/${params.itemId}/reviews/photos`, {
+        params: {
+            offset: params.offset,
+            limit: params.limit,
+        },
+    });
     return response.data;
 };

--- a/src/api/order/orderApi.ts
+++ b/src/api/order/orderApi.ts
@@ -1,0 +1,81 @@
+import { api } from '../axios';
+
+// 주문서 조회 요청 타입 (Step 1: 배송지 정보는 보내지 않음, BE가 기본 배송지 사용)
+export interface CreateOrderSheetRequest {
+  item_id: string;
+  option_item_ids: string[];
+  quantity: number;
+  // delivery_address_id는 Step 1에서 보내지 않음 (문서 참고)
+}
+
+// 주문서 조회 응답 타입
+export interface CreateOrderSheetResponse {
+  resultType: 'SUCCESS' | 'ERROR';
+  error: null | {
+    code: string;
+    message: string;
+  };
+  success: {
+    receipt_number: string; // 주문 번호 (merchant_uid로 사용)
+    delivery_fee: number; // 배송비
+    payment: {
+      product_amount: number; // 상품 금액
+      delivery_fee: number; // 배송비
+      total_amount: number; // 총 결제 금액
+    };
+  };
+}
+
+// 배송지 정보 (new_address용)
+export interface NewDeliveryAddress {
+  postal_code: string;
+  address: string;
+  address_detail: string;
+  recipient_name: string;
+  phone: string;
+  address_name: string;
+}
+
+// 주문 생성 요청 타입 (ITEM 결제)
+export interface CreateOrderRequest {
+  merchant_uid: string; // receipt_number를 merchant_uid로 사용
+  item_id: string;
+  option_item_ids: string[]; // 선택된 옵션 아이템 ID 배열
+  quantity: number;
+  // delivery_address_id 또는 new_address 둘 중 하나만 전달
+  delivery_address_id?: string; // 기존 배송지 ID
+  new_address?: NewDeliveryAddress; // 새 배송지 정보
+}
+
+// 주문 생성 응답 타입
+export interface CreateOrderResponse {
+  resultType: 'SUCCESS' | 'ERROR';
+  error: null | {
+    code: string;
+    message: string;
+  };
+  success: {
+    order_id: string;
+    payment_required: boolean;
+    payment_info: {
+      amount: number;
+      merchant_uid: string;
+    };
+  };
+}
+
+// 주문서 조회 API (POST /orders/sheet)
+export const createOrderSheet = async (
+  payload: CreateOrderSheetRequest
+): Promise<CreateOrderSheetResponse> => {
+  const response = await api.post<CreateOrderSheetResponse>('/orders/sheet', payload);
+  return response.data;
+};
+
+// 주문 생성 API (POST /orders)
+export const createOrder = async (
+  payload: CreateOrderRequest
+): Promise<CreateOrderResponse> => {
+  const response = await api.post<CreateOrderResponse>('/orders', payload);
+  return response.data;
+};

--- a/src/components/domain/cart/EmptyCart.tsx
+++ b/src/components/domain/cart/EmptyCart.tsx
@@ -19,7 +19,7 @@ const EmptyCart = () => {
         <Button
           variant="primary"
           className="!px-[2.5rem] !py-[1.125rem] body-b0-bd flex items-center gap-[0.5rem]"
-          onClick={() => navigate('/*추후 라우팅 추가*/')}
+          onClick={() => navigate('/market')}
         >
           마켓 둘러보기
           <img

--- a/src/hooks/domain/market/useMarketProductList.ts
+++ b/src/hooks/domain/market/useMarketProductList.ts
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { getMarketProductList } from '../../../api/market/market';
-import type { GetMarketProductDetailResponse } from '../../../types/api/market/market';
+import type { MarketProductItem } from '../../../types/api/market/market';
 import { getMarketProductDetail } from '../../../api/market/market'; 
 import { getMarketProductPhotoReview } from '../../../api/market/market';
 import { getMarketProductReviewList } from '../../../api/market/market';
@@ -38,7 +38,7 @@ export const useMarketProductList = () => {
     staleTime: 1000 * 30,
   });
 
-  const products: GetMarketProductDetailResponse[] = productListResponse?.success.items ?? [];  
+  const products: MarketProductItem[] = productListResponse?.success.items ?? [];  
   const hasNextPage = products.length >= 15;
   const totalPages = currentPage + (hasNextPage ? 1 : 0);
 

--- a/src/hooks/domain/market/useMarketProductList.ts
+++ b/src/hooks/domain/market/useMarketProductList.ts
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { getMarketProductList } from '../../../api/market/market';
-import type { MarketProductItem } from '../../../types/api/market/market';
+import type { GetMarketProductDetailResponse } from '../../../types/api/market/market';
 import { getMarketProductDetail } from '../../../api/market/market'; 
 
 
@@ -37,7 +37,7 @@ export const useMarketProductList = () => {
     staleTime: 1000 * 30,
   });
 
-  const products: MarketProductItem[] = productListResponse?.success.items ?? [];
+  const products: GetMarketProductDetailResponse[] = productListResponse?.success.items ?? [];
   const hasNextPage = products.length >= 15;
   const totalPages = currentPage + (hasNextPage ? 1 : 0);
 
@@ -84,16 +84,15 @@ export const useMarketProductDetail = (itemId: string | undefined) => {
   const { data: productDetailResponse } = useQuery({
     queryKey: ['market-product-detail', itemId],
     queryFn: async () => {
-
-       const data = await getMarketProductDetail({ item_id: itemId ?? '' });
-       return data;
+   
+      const data = await getMarketProductDetail({ item_id: itemId ?? '' });
+      return data;
     },
     enabled: !!itemId,
     staleTime: 1000 * 30,
-    retry: 1,
   });
   
   return {
-    productDetailResponse,
+    productDetailResponse
   };
 };

--- a/src/hooks/domain/market/useMarketProductList.ts
+++ b/src/hooks/domain/market/useMarketProductList.ts
@@ -3,7 +3,8 @@ import { useQuery } from '@tanstack/react-query';
 import { getMarketProductList } from '../../../api/market/market';
 import type { GetMarketProductDetailResponse } from '../../../types/api/market/market';
 import { getMarketProductDetail } from '../../../api/market/market'; 
-
+import { getMarketProductPhotoReview } from '../../../api/market/market';
+import { getMarketProductReviewList } from '../../../api/market/market';
 
 export type MarketCategorySelection = {
   categoryTitle: string;
@@ -37,7 +38,7 @@ export const useMarketProductList = () => {
     staleTime: 1000 * 30,
   });
 
-  const products: GetMarketProductDetailResponse[] = productListResponse?.success.items ?? [];
+  const products: GetMarketProductDetailResponse[] = productListResponse?.success.items ?? [];  
   const hasNextPage = products.length >= 15;
   const totalPages = currentPage + (hasNextPage ? 1 : 0);
 
@@ -94,5 +95,46 @@ export const useMarketProductDetail = (itemId: string | undefined) => {
   
   return {
     productDetailResponse
+  };
+};
+
+export const useMarketProductPhotoReview = (itemId: string | undefined) => {
+  const { data: photoReviewResponse } = useQuery({
+    queryKey: ['market-product-photo-review', itemId],
+    queryFn: async () => {
+      const data = await getMarketProductPhotoReview({ itemId: itemId ?? '', offset: 0, limit: 15 });
+      return data;
+    },
+    enabled: !!itemId,
+    staleTime: 1000 * 30,
+  });
+  
+  return {
+    photoReviewResponse
+  };
+};
+
+export const useMarketProductReviewList = (
+  itemId: string | undefined,
+  page: number = 1,
+  sort: 'latest' | 'star_high' | 'star_low' = 'latest'
+) => {
+  const { data: reviewListResponse } = useQuery({
+    queryKey: ['market-product-review-list', itemId, page, sort],
+    queryFn: async () => {
+      const data = await getMarketProductReviewList({ 
+        itemId: itemId ?? '', 
+        page, 
+        limit: 15, 
+        sort 
+      });
+      return data;
+    },
+    enabled: !!itemId,
+    staleTime: 1000 * 30,
+  });
+  
+  return {
+    reviewListResponse
   };
 };

--- a/src/hooks/domain/payment/useOrderSheet.ts
+++ b/src/hooks/domain/payment/useOrderSheet.ts
@@ -1,0 +1,54 @@
+// 주문서 조회 커스텀 훅
+import { useState, useEffect } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { fetchOrderSheet } from '../../../services/payment/paymentService';
+
+interface UseOrderSheetParams {
+  itemId: string;
+  optionItemIds: string[];
+  quantity: number;
+  enabled?: boolean;
+}
+
+/**
+ * 주문서 조회 훅 (배송비 및 총 금액 조회)
+ */
+export const useOrderSheet = ({
+  itemId,
+  optionItemIds,
+  quantity,
+  enabled = true,
+}: UseOrderSheetParams) => {
+  const [shippingFee, setShippingFee] = useState(0);
+  const [totalPrice, setTotalPrice] = useState(0);
+
+  const { data: orderSheet, isLoading, error } = useQuery({
+    queryKey: ['order-sheet', itemId, optionItemIds, quantity],
+    queryFn: () => fetchOrderSheet({
+      item_id: itemId,
+      option_item_ids: optionItemIds,
+      quantity,
+    }),
+    enabled: enabled && !!itemId && optionItemIds.length >= 0,
+    staleTime: 1000 * 30, // 30초
+  });
+
+  useEffect(() => {
+    if (orderSheet) {
+      const deliveryFee = orderSheet.delivery_fee || orderSheet.payment?.delivery_fee || 0;
+      const totalAmount = orderSheet.payment?.total_amount || 0;
+      
+      setShippingFee(deliveryFee);
+      setTotalPrice(totalAmount);
+    }
+  }, [orderSheet]);
+
+  return {
+    orderSheet,
+    shippingFee,
+    totalPrice,
+    isLoading,
+    error,
+    receiptNumber: orderSheet?.receipt_number,
+  };
+};

--- a/src/hooks/domain/payment/usePayment.ts
+++ b/src/hooks/domain/payment/usePayment.ts
@@ -1,0 +1,244 @@
+// 결제 커스텀 훅
+import { useState, useCallback } from 'react';
+import {
+  loadPortOneSDK,
+  requestPortonePayment,
+  fetchOrderSheet,
+  createOrderRequest,
+  verifyPaymentRequest,
+} from '../../../services/payment/paymentService';
+import type { DeliveryAddress, PaymentError, PaymentErrorType, PaymentResponse } from '../../../types/payment/payment';
+import { PaymentStatus, PaymentErrorType as ErrorType } from '../../../types/payment/payment';
+import { formatApprovedAt } from '../../../utils/payment/formatPaymentDate';
+
+interface UsePaymentParams {
+  product: {
+    id: string;
+    title: string;
+    price: number;
+    optionPrice?: number;
+    quantity: number;
+    selectedOptions?: Record<string, string>;
+    image: string;
+    seller: string;
+    option?: string;
+  };
+  deliveryAddress: DeliveryAddress;
+  deliveryAddressId?: string | null; // 기존 배송지 ID (선택 시)
+  onSuccess?: (orderData: unknown) => void;
+  onError?: (error: PaymentError) => void;
+}
+
+interface UsePaymentReturn {
+  processPayment: () => Promise<void>;
+  status: PaymentStatus;
+  error: PaymentError | null;
+  isProcessing: boolean;
+}
+
+/**
+ * 결제 처리 커스텀 훅
+ */
+export const usePayment = ({
+  product,
+  deliveryAddress,
+  deliveryAddressId,
+  onSuccess,
+  onError,
+}: UsePaymentParams): UsePaymentReturn => {
+  const [status, setStatus] = useState<PaymentStatus>(PaymentStatus.IDLE);
+  const [error, setError] = useState<PaymentError | null>(null);
+
+  const createError = useCallback((
+    type: PaymentErrorType,
+    message: string,
+    originalError?: Error
+  ): PaymentError => {
+    return { type, message, originalError };
+  }, []);
+
+  const handleError = useCallback((
+    type: PaymentErrorType,
+    message: string,
+    originalError?: Error
+  ) => {
+    const paymentError = createError(type, message, originalError);
+    setError(paymentError);
+    setStatus(PaymentStatus.FAILED);
+    onError?.(paymentError);
+  }, [createError, onError]);
+
+  const processPayment = useCallback(async () => {
+    if (status === PaymentStatus.PROCESSING) return;
+
+    setStatus(PaymentStatus.PROCESSING);
+    setError(null);
+
+    try {
+      // 1. 배송지 정보 검증
+      if (!deliveryAddress.zipcode || !deliveryAddress.address || 
+          !deliveryAddress.recipient || !deliveryAddress.phone) {
+        throw createError(
+          ErrorType.VALIDATION_ERROR,
+          '배송지 정보를 모두 입력해주세요.'
+        );
+      }
+
+      // 2. option_item_ids 배열 생성
+      const optionItemIds: string[] = [];
+      if (product.selectedOptions && typeof product.selectedOptions === 'object') {
+        Object.values(product.selectedOptions).forEach((optionItemId) => {
+          if (optionItemId && typeof optionItemId === 'string') {
+            optionItemIds.push(optionItemId);
+          }
+        });
+      }
+
+      // 3. 주문서 조회 (POST /orders/sheet)
+      const orderSheet = await fetchOrderSheet({
+        item_id: product.id,
+        option_item_ids: optionItemIds,
+        quantity: product.quantity,
+      });
+
+      const receiptNumber = orderSheet.receipt_number;
+      const deliveryFee = orderSheet.delivery_fee || orderSheet.payment?.delivery_fee || 0;
+
+      // 4. 주문 생성 (POST /orders)
+      // delivery_address_id 또는 new_address 둘 중 하나만 전달
+      const orderPayload: {
+        merchant_uid: string;
+        item_id: string;
+        option_item_ids: string[];
+        quantity: number;
+        delivery_address_id?: string;
+        new_address?: {
+          postal_code: string;
+          address: string;
+          address_detail: string;
+          recipient_name: string;
+          phone: string;
+          address_name: string;
+        };
+      } = {
+        merchant_uid: receiptNumber,
+        item_id: product.id,
+        option_item_ids: optionItemIds,
+        quantity: product.quantity,
+      };
+
+      if (deliveryAddressId) {
+        // 기존 배송지 사용
+        orderPayload.delivery_address_id = deliveryAddressId;
+      } else {
+        // 신규 배송지 사용
+        orderPayload.new_address = {
+          postal_code: deliveryAddress.zipcode,
+          address: deliveryAddress.address,
+          address_detail: deliveryAddress.detailAddress || '',
+          recipient_name: deliveryAddress.recipient,
+          phone: deliveryAddress.phone,
+          address_name: deliveryAddress.name || '배송지',
+        };
+      }
+
+      const order = await createOrderRequest(orderPayload);
+
+      const { order_id, payment_info } = order;
+
+      // 5. Portone SDK 로드
+      await loadPortOneSDK();
+
+      // 6. Portone 결제창 호출
+      requestPortonePayment(
+        {
+          merchant_uid: payment_info.merchant_uid,
+          name: product.title,
+          amount: payment_info.amount,
+          buyer_name: deliveryAddress.recipient,
+        },
+        async (rsp: PaymentResponse) => {
+          if (rsp.success) {
+            try {
+              // 7. 결제 검증 (POST /orders/verify)
+              if (!rsp.imp_uid) {
+                throw createError(
+                  ErrorType.VERIFICATION_ERROR,
+                  '결제 고유번호를 가져올 수 없습니다.'
+                );
+              }
+
+              await verifyPaymentRequest({
+                order_id,
+                imp_uid: rsp.imp_uid,
+              });
+
+              // 8. 결제 완료 데이터 생성
+              const orderData = {
+                orderNumber: payment_info.merchant_uid,
+                orderId: order_id,
+                deliveryInfo: {
+                  name: deliveryAddress.name,
+                  recipient: deliveryAddress.recipient,
+                  phone: deliveryAddress.phone,
+                  address: `(${deliveryAddress.zipcode}) ${deliveryAddress.address} ${deliveryAddress.detailAddress}`,
+                },
+                product: {
+                  image: product.image,
+                  title: product.title,
+                  option: product.option || '옵션 없음',
+                  seller: product.seller,
+                },
+                payment: {
+                  totalAmount: payment_info.amount,
+                  productAmount: product.price + (product.optionPrice || 0),
+                  shippingFee: deliveryFee,
+                  method: '카드 간편결제',
+                  paidAmount: rsp.paid_amount,
+                  approvedAt: formatApprovedAt(new Date()),
+                },
+              };
+
+              setStatus(PaymentStatus.SUCCESS);
+              onSuccess?.(orderData);
+            } catch (verifyError) {
+              handleError(
+                ErrorType.VERIFICATION_ERROR,
+                '결제 검증에 실패했습니다. 고객센터로 문의해주세요.',
+                verifyError as Error
+              );
+            }
+          } else {
+            handleError(
+              ErrorType.PORTONE_PAYMENT_ERROR,
+              rsp.error_msg || '결제에 실패했습니다.'
+            );
+          }
+        }
+      );
+    } catch (err) {
+      const error = err as Error | PaymentError;
+      
+      // 에러 타입별 처리
+      if ('type' in error && error.type) {
+        // 이미 PaymentError인 경우
+        handleError(error.type, error.message, error.originalError);
+      } else if (error.message.includes('주문서')) {
+        handleError(ErrorType.ORDER_SHEET_ERROR, error.message, error as Error);
+      } else if (error.message.includes('주문 생성')) {
+        handleError(ErrorType.ORDER_CREATE_ERROR, error.message, error as Error);
+      } else if (error.message.includes('포트원')) {
+        handleError(ErrorType.PORTONE_LOAD_ERROR, error.message, error as Error);
+      } else {
+        handleError(ErrorType.VALIDATION_ERROR, error.message || '결제 처리에 실패했습니다.', error as Error);
+      }
+    }
+  }, [product, deliveryAddress, deliveryAddressId, status, createError, handleError, onSuccess]);
+
+  return {
+    processPayment,
+    status,
+    error,
+    isProcessing: status === PaymentStatus.PROCESSING,
+  };
+};

--- a/src/pages/market/MarketProductDetailPage.tsx
+++ b/src/pages/market/MarketProductDetailPage.tsx
@@ -27,9 +27,6 @@ const formatPrice = (price: number) => {
   return price.toLocaleString('ko-KR');
 };
 
-
-
-
 const MarketProductDetailPage = () => {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
@@ -244,7 +241,7 @@ const MarketProductDetailPage = () => {
        
         <div className="flex-1 flex flex-col">
           <div className="flex items-center justify-between">
-            <div className="flex items-center gap-[0.75rem]">
+            <div className="flex items-center gap-[0.75rem] cursor-pointer" onClick={() => navigate(`/profile/${product.reformer.owner_id}`)}>
               <div className="w-[2.95725rem] h-[2.95725rem] rounded-full bg-[var(--color-gray-20)] flex items-center justify-center">
                 <span className="body-b1-rg text-[var(--color-gray-60)]">
                   <img src={product.reformer.profile_image} alt="profile" className="w-full h-full object-cover rounded-full" />

--- a/src/pages/market/MarketProductDetailPage.tsx
+++ b/src/pages/market/MarketProductDetailPage.tsx
@@ -539,7 +539,7 @@ const MarketProductDetailPage = () => {
                 <div className="flex-1 border-t border-b border-[var(--color-line-gray-40)] py-[1.125rem] flex flex-col items-center gap-[0.5rem]">
                   <span className="body-b0-rg text-[var(--color-gray-50)]">후기</span>
                   <span className="heading-h4-bd text-[1.875rem] text-[var(--color-black)]">
-                    {review_count}개
+                    {product.reformer.review_count}개
                   </span>
                 </div>
                

--- a/src/pages/market/MarketProductDetailPage.tsx
+++ b/src/pages/market/MarketProductDetailPage.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef, useMemo } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
+import xIcon from '../../assets/icons/x.svg';
 import { ImageCarousel } from '../../components/common/product/Image';
 import OptionQuantity from '../../components/common/product/option/option-quantity-button/OptionQuantity';  
 import ProductInfoToggle from '../../components/common/product/detail/ProductInfoToggle';
@@ -292,8 +293,8 @@ const MarketProductDetailPage = () => {
           {/* 선택된 옵션이 있을 때만 표시 */}
           {Object.keys(selectedOptions).length > 0 && (
             <div className="bg-[var(--color-gray-20)] p-[0.625rem] flex flex-col gap-[1.75rem] mt-[2.25rem]">
-              <div className='flex flex-col gap-[0.5rem]'>
-                <span className="body-b1-rg px-[0.625rem]">
+              <div className=' flex items-center justify-between gap-[0.5rem]'>
+                <span className="body-b1-rg px-[0.625rem] flex items-center justify-between w-full">
                   {product.option_groups
                     .map((group) => {
                       const selectedOptionId = selectedOptions[group.option_group_id];
@@ -306,11 +307,14 @@ const MarketProductDetailPage = () => {
                       return '';
                     })
                     .filter(Boolean)
-                    .join(', ')}
+                    .join(', ')}                  
+                      <img src={xIcon} alt="x" className="w-10 h-10 cursor-pointer" onClick={() => setSelectedOptions({})} 
+                      />
+                 
                 </span>
               </div>
-              <div className="flex items-center justify-between">
-                
+
+              <div className="flex items-center justify-between">              
                 <OptionQuantity
                   quantity={quantity}
                   onIncrease={() => setQuantity(quantity + 1)}
@@ -319,7 +323,7 @@ const MarketProductDetailPage = () => {
                
                 <p className="body-b0-bd px-[0.625rem]">
                   {formatPrice((basePrice + optionPrice) * quantity)}원
-                  {optionPrice > 0 && ` (옵션 +${formatPrice(optionPrice)}원)`}
+                 
                 </p>
               </div>
             </div>
@@ -335,6 +339,7 @@ const MarketProductDetailPage = () => {
             </div>
             
             <div className="flex flex-col gap-[0.625rem]">
+              
               <div className="flex gap-[0.625rem]">
                 <Button
                   variant="white"
@@ -350,15 +355,31 @@ const MarketProductDetailPage = () => {
                   />
                   <span className="body-b0-bd text-[1.25rem]">찜하기</span>
                 </Button>
-                <button className="flex-1 h-[4.625rem] bg-white border border-[var(--color-line-gray-40)] rounded-[0.625rem] flex items-center justify-center gap-[0.625rem]">
+                <Button
+                  variant="white"
+                  onClick={() => {
+                    navigate(`/market/product/${id}/cart`);
+                  }}
+                  className="flex items-center justify-center gap-2 flex-1 h-[4.625rem]"
+                >
                   <img src={cartIcon} alt="장바구니" className="w-10 h-10" />
                   <span className="body-b0-bd text-[1.25rem]">장바구니</span>
-                </button>
-                <button className="flex-1 h-[4.625rem] bg-white border border-[var(--color-line-gray-40)] rounded-[0.625rem] flex items-center justify-center gap-[0.625rem]">
-                  <img src={chatIcon} alt="문의하기" className="w-10 h-10" />
+                </Button>
+                 
+               <Button
+                  variant="white"
+                  onClick={() => {
+                    navigate(`/market/product/${id}/chat`);
+                  }}
+                  className="flex items-center justify-center gap-2 flex-1 h-[4.625rem]"
+                >
+                  <img src={chatIcon} alt="채팅" className="w-10 h-10" />
                   <span className="body-b0-bd text-[1.25rem]">문의하기</span>
-                </button>
+                </Button>
+                  
+               
               </div>
+
               <button 
                 onClick={() => {
                   const allOptionsSelected = optionGroups.every(group => 
@@ -458,15 +479,13 @@ const MarketProductDetailPage = () => {
 
         <div ref={reformerRef} id="reformer-info" className="scroll-mt-[100px] mx-[7.125rem] pt-[6.25rem]">
           <div className="flex gap-[3.3125rem] items-start">
-            <div className="w-[8.4375rem] h-[8.4375rem] rounded-full bg-[var(--color-gray-20)] flex items-center justify-center">
-              <span className="heading-h4-bd text-[2rem] text-[var(--color-gray-60)]">
-                {owner_nickname.charAt(0)}
-              </span>
+            <div className="w-[8.4375rem] h-[8.4375rem] rounded-full bg-[var(--color-gray-20)] flex items-center justify-center">             
+                 <img src={product.reformer.profile_image} alt="profile" className="w-full h-full object-cover rounded-full" />
             </div>
             <div className="flex-1 flex flex-col gap-[2.625rem]">
               <div className="flex flex-col gap-[0.75rem]">
                 <h2 className="heading-h4-bd text-[1.875rem] text-[var(--color-black)]">
-                  {owner_nickname}
+                  {product.reformer.nickname}
                 </h2>
                 <div className="flex items-center gap-[0.625rem]">
                   <div className="flex gap-[0.375rem]">
@@ -480,7 +499,7 @@ const MarketProductDetailPage = () => {
                     ))}
                   </div>
                   <span className="body-b1-sb text-[var(--color-black)]">
-                    {star}
+                    {product.reformer.star}
                   </span>
                 </div>
               </div>
@@ -497,8 +516,20 @@ const MarketProductDetailPage = () => {
                     {review_count}개
                   </span>
                 </div>
+               
               </div>
-              <button className="w-full h-[4.625rem] border border-[var(--color-mint-1)] rounded-[0.625rem] flex items-center justify-center">
+              <div className="flex-1 flex flex-col gap-[0.5rem]">
+                  <ol className="flex flex-col gap-[0.5rem]">
+                    <li className="body-b1-rg text-[var(--color-gray-60)]">
+                      - {product.content} 
+                    </li>
+                  </ol>
+                  
+                  </div>
+              <button                
+                className="w-full h-[4.625rem] border border-[var(--color-mint-1)] rounded-[0.625rem] flex items-center justify-center cursor-pointer hover:opacity-90 transition-opacity"
+                onClick={() => navigate(`/profile/${product.reformer.owner_id}`)}
+              >
                 <span className="body-b0-bd text-[1.25rem] text-[var(--color-mint-1)]">
                   피드 보러가기
                 </span>

--- a/src/pages/market/MarketProductDetailPage.tsx
+++ b/src/pages/market/MarketProductDetailPage.tsx
@@ -547,7 +547,7 @@ const MarketProductDetailPage = () => {
               <div className="flex-1 flex flex-col gap-[0.5rem]">
                   <ol className="flex flex-col gap-[0.5rem]">
                     <li className="body-b1-rg text-[var(--color-gray-60)]">
-                      - {product.content} 
+                      {product.reformer.bio}
                     </li>
                   </ol>
                   

--- a/src/pages/market/MarketPurchasePage.tsx
+++ b/src/pages/market/MarketPurchasePage.tsx
@@ -1,81 +1,121 @@
-import { useState } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import Input from '../../components/domain/purchase/Input';
 import Button2 from '../../components/common/button/Button2';
+import DaumPostcode from 'react-daum-postcode';
+import { usePayment } from '../../hooks/domain/payment/usePayment';
+import { useOrderSheet } from '../../hooks/domain/payment/useOrderSheet';
+import type { DeliveryAddress } from '../../types/payment/payment';
 
-const mockProduct = {
-  id: 1,
-  title: '[야구 유니폼 리폼] 내가 제일 좋아하는 선수의 유니폼이 짐색으로 재탄생된다면? 한화·롯데 등 야구단 유니폼 리폼해드립니다.',
-  seller: '침착한 대머리독수리',
-  image: '/Home/images/p1.jpg',
-  option: '옵션 샘플 테스트 1번 (+10,000원)',
-  shipping: '무료 배송',
-  quantity: 1,
-  price: 75000,
-  optionPrice: 10000,
-};
 
 const MarketPurchasePage = () => {
   const location = useLocation();
   const navigate = useNavigate();
   const { id } = useParams<{ id: string }>();
   
-  const product = location.state?.product || mockProduct;
+  const product = location.state?.product;
   
   const [activeTab, setActiveTab] = useState<'existing' | 'new'>('existing');
+  const [isPostcodeOpen, setIsPostcodeOpen] = useState(false);
+  const [deliveryAddress, setDeliveryAddress] = useState<DeliveryAddress>({
+    zipcode: '',
+    address: '',
+    detailAddress: '',
+    name: '',
+    recipient: '',
+    phone: '',
+  });
   
-  const productPrice = product.price;
-  const optionPrice = product.optionPrice || 0;
-  const shippingFee = 0; 
-  const totalPrice = (productPrice + optionPrice) * product.quantity;
+  // option_item_ids 계산
+  const optionItemIds = useMemo(() => {
+    const ids: string[] = [];
+    if (product?.selectedOptions && typeof product.selectedOptions === 'object') {
+      Object.values(product.selectedOptions).forEach((optionItemId) => {
+        if (optionItemId && typeof optionItemId === 'string') {
+          ids.push(optionItemId);
+        }
+      });
+    }
+    return ids;
+  }, [product?.selectedOptions]);
+
+  // 주문서 조회 (배송비 및 총 금액)
+  const { shippingFee, totalPrice, isLoading: isOrderSheetLoading } = useOrderSheet({
+    itemId: id || '',
+    optionItemIds,
+    quantity: product?.quantity || 1,
+    enabled: !!id && !!product,
+  });
+
+  const productPrice = product?.price || 0;
+  const optionPrice = product?.optionPrice || 0;
+
+  // 결제 처리 (early return 전에 호출)
+  const { processPayment, isProcessing, error: paymentError } = usePayment({
+    product: {
+      id: id || '',
+      title: product?.title || '',
+      price: productPrice,
+      optionPrice,
+      quantity: product?.quantity || 1,
+      selectedOptions: product?.selectedOptions,
+      image: product?.image || '',
+      seller: product?.seller || '',
+      option: product?.option,
+    },
+    deliveryAddress,
+    deliveryAddressId: null,
+    onSuccess: (orderData) => {
+      if (id) {
+        navigate(`/market/product/${id}/purchase/complete`, {
+          state: { order: orderData },
+        });
+      }
+    },
+    onError: (error) => {
+      alert(error.message);
+    },
+  });
+
+  // product가 없으면 상품 상세 페이지로 리다이렉트
+  useEffect(() => {
+    if (!product || !id) {
+      navigate(`/market/product/${id || ''}`);
+    }
+  }, [product, id, navigate]);
 
   const formatPrice = (price: number) => {
     return price.toLocaleString('ko-KR');
   };
 
-  const handlePayment = () => {
-    
-    const orderNumber = Date.now().toString().padStart(11, '0');
-    
-   
-    const orderData = {
-      orderNumber,
-      deliveryInfo: {
-        name: '학교',
-        recipient: '홍길동',
-        phone: '010-0000-0000',
-        address: '(04310) 서울 용산구 청파구47길 100 명신관 302호',
-      },
-      product: {
-        image: product.image,
-        title: product.title,
-        option: product.option || '옵션 없음',
-        seller: product.seller,
-        additionalItems: 3, // 임시 값
-      },
-      payment: {
-        totalAmount: totalPrice,
-        productAmount: productPrice + optionPrice,
-        shippingFee: shippingFee,
-        method: '카드 간편결제',
-        bank: '신한은행',
-        cardNumber: '0000-****-****-0000',
-        approvedAt: (() => {
-          const now = new Date();
-          const year = now.getFullYear();
-          const month = String(now.getMonth() + 1).padStart(2, '0');
-          const day = String(now.getDate()).padStart(2, '0');
-          const hour = String(now.getHours()).padStart(2, '0');
-          const minute = String(now.getMinutes()).padStart(2, '0');
-          return `${year}.${month}.${day} ${hour}.${minute}`;
-        })(),
-      },
-    };
+  // 우편번호 검색 완료 핸들러
+  const handlePostcodeComplete = (data: {
+    zonecode: string;
+    roadAddress: string;
+    jibunAddress?: string;
+    address: string;
+  }) => {
+    setDeliveryAddress((prev) => ({
+      ...prev,
+      zipcode: data.zonecode,
+      address: data.roadAddress || data.address,
+    }));
+    setIsPostcodeOpen(false);
+  };
 
-  
-    navigate(`/market/product/${id}/purchase/complete`, {
-      state: { order: orderData },
-    });
+  if (!product || !id) {
+    return null;
+  }
+
+  const handlePayment = () => {
+    // 배송지 정보 검증
+    if (!deliveryAddress.zipcode || !deliveryAddress.address || 
+        !deliveryAddress.recipient || !deliveryAddress.phone) {
+      alert('배송지 정보를 모두 입력해주세요.');
+      return;
+    }
+
+    processPayment();
   };
 
   return (
@@ -122,71 +162,121 @@ const MarketPurchasePage = () => {
 
              
               <div className="flex flex-col gap-[1.875rem] mt-[2.875rem]">
-                
-                <div className="flex gap-[2rem] items-center">
-                  <label className="body-b1-sb text-[var(--color-gray-60)] w-[4.1875rem]">
-                    배송지명
-                  </label>
-                  <div className="w-[29.625rem]">
-                    <Input value="학교" readOnly />
+                {/* 배송지 입력 필드 (기존/신규 공통) */}
+                <div className="flex flex-col gap-[1.875rem]">
+                  <div className="flex gap-[2rem] items-center">
+                    <label className="body-b1-sb text-[var(--color-gray-60)] w-[4.1875rem]">
+                      배송지명
+                    </label>
+                    <div className="w-[29.625rem]">
+                      <Input 
+                        value={deliveryAddress.name} 
+                        onChange={(e) => setDeliveryAddress((prev) => ({ ...prev, name: e.target.value }))}
+                        placeholder="배송지명을 입력해주세요"
+                      />
+                    </div>
                   </div>
-                </div>
 
                
-                <div className="flex gap-[2rem] items-center">
-                  <label className="body-b1-sb text-[var(--color-gray-60)] w-[4.1875rem]">
-                    <span>수령인</span>
-                    <span className="text-[var(--color-red-1)]"> *</span>
-                  </label>
-                  <div className="w-[29.625rem]">
-                    <Input value="홍길동" readOnly />
+                  <div className="flex gap-[2rem] items-center">
+                    <label className="body-b1-sb text-[var(--color-gray-60)] w-[4.1875rem]">
+                      <span>수령인</span>
+                      <span className="text-[var(--color-red-1)]"> *</span>
+                    </label>
+                    <div className="w-[29.625rem]">
+                      <Input 
+                        value={deliveryAddress.recipient} 
+                        onChange={(e) => setDeliveryAddress((prev) => ({ ...prev, recipient: e.target.value }))}
+                        placeholder="수령인을 입력해주세요"
+                      />
+                    </div>
                   </div>
-                </div>
 
               
-                <div className="flex gap-[2rem] items-start">
-                  <label className="body-b1-sb text-[var(--color-gray-60)] w-[4.1875rem] pt-[0.8125rem]">
-                    <span>배송지</span>
-                    <span className="text-[var(--color-red-1)]"> *</span>
-                  </label>
-                  <div className="flex flex-col gap-[0.9375rem] w-[41.0625rem]">
-                   
-                    <div className="flex gap-[0.9375rem] items-start">
-                      <div className="w-[29.625rem]">
-                        <Input value="04310" readOnly />
+                  <div className="flex gap-[2rem] items-start">
+                    <label className="body-b1-sb text-[var(--color-gray-60)] w-[4.1875rem] pt-[0.8125rem]">
+                      <span>배송지</span>
+                      <span className="text-[var(--color-red-1)]"> *</span>
+                    </label>
+                    <div className="flex flex-col gap-[0.9375rem] w-[41.0625rem]">
+                     
+                      <div className="flex gap-[0.9375rem] items-start">
+                        <div className="w-[29.625rem]">
+                          <Input value={deliveryAddress.zipcode} placeholder="우편번호" readOnly />
+                        </div>
+                        <Button2 
+                          className="w-[10.5rem] h-[3.375rem]"
+                          onClick={() => setIsPostcodeOpen(true)}
+                        >
+                          우편번호 검색
+                        </Button2>
                       </div>
-                      <Button2 className="w-[10.5rem] h-[3.375rem]">
-                        우편번호 검색
-                      </Button2>
-                    </div>
-                   
-                    <div className="w-[29.625rem]">
-                    <Input value="서울 용산구 청파로47길 100" readOnly />
-                    </div>
-                   
-                    <div className="w-[29.625rem]">
-                    <Input value="명신관 302호" readOnly />
+                     
+                      <div className="w-[29.625rem]">
+                      <Input value={deliveryAddress.address} placeholder="주소" readOnly />
+                      </div>
+                     
+                      <div className="w-[29.625rem]">
+                      <Input 
+                        value={deliveryAddress.detailAddress} 
+                        onChange={(e) => setDeliveryAddress((prev) => ({ ...prev, detailAddress: e.target.value }))}
+                        placeholder="상세주소"
+                      />
+                      </div>
                     </div>
                   </div>
-                </div>
 
-                
-                <div className="flex gap-[2rem] items-center">
-                  <label className="body-b1-sb text-[var(--color-gray-60)] w-[4.1875rem]">
-                    <span>연락처</span>
-                    <span className="text-[var(--color-red-1)]"> *</span>
-                  </label>
-                  <div className="flex items-center gap-[1.3125rem]">
-                    <div className="w-[7.8125rem]">
-                      <Input value="010" readOnly />
-                    </div>
-                    <span className="body-b0-rg text-black">-</span>
-                    <div className="w-[7.8125rem]">
-                      <Input value="0000" readOnly />
-                    </div>
-                    <span className="body-b0-rg text-black">-</span>
-                    <div className="w-[7.8125rem]">
-                      <Input value="0000" readOnly />
+                  
+                  <div className="flex gap-[2rem] items-center">
+                    <label className="body-b1-sb text-[var(--color-gray-60)] w-[4.1875rem]">
+                      <span>연락처</span>
+                      <span className="text-[var(--color-red-1)]"> *</span>
+                    </label>
+                    <div className="flex items-center gap-[1.3125rem]">
+                      <div className="w-[7.8125rem]">
+                        <Input 
+                          value={deliveryAddress.phone.split('-')[0] || ''} 
+                          onChange={(e) => {
+                            const parts = deliveryAddress.phone.split('-');
+                            setDeliveryAddress((prev) => ({ 
+                              ...prev, 
+                              phone: `${e.target.value}-${parts[1] || ''}-${parts[2] || ''}`.replace(/-$/, '')
+                            }));
+                          }}
+                          placeholder="010"
+                          maxLength={3}
+                        />
+                      </div>
+                      <span className="body-b0-rg text-black">-</span>
+                      <div className="w-[7.8125rem]">
+                        <Input 
+                          value={deliveryAddress.phone.split('-')[1] || ''} 
+                          onChange={(e) => {
+                            const parts = deliveryAddress.phone.split('-');
+                            setDeliveryAddress((prev) => ({ 
+                              ...prev, 
+                              phone: `${parts[0] || ''}-${e.target.value}-${parts[2] || ''}`.replace(/-$/, '')
+                            }));
+                          }}
+                          placeholder="0000"
+                          maxLength={4}
+                        />
+                      </div>
+                      <span className="body-b0-rg text-black">-</span>
+                      <div className="w-[7.8125rem]">
+                        <Input 
+                          value={deliveryAddress.phone.split('-')[2] || ''} 
+                          onChange={(e) => {
+                            const parts = deliveryAddress.phone.split('-');
+                            setDeliveryAddress((prev) => ({ 
+                              ...prev, 
+                              phone: `${parts[0] || ''}-${parts[1] || ''}-${e.target.value}`.replace(/-$/, '')
+                            }));
+                          }}
+                          placeholder="0000"
+                          maxLength={4}
+                        />
+                      </div>
                     </div>
                   </div>
                 </div>
@@ -277,15 +367,40 @@ const MarketPurchasePage = () => {
             
             <button 
               onClick={handlePayment}
-              className="bg-[var(--color-mint-0)] flex gap-[0.625rem] h-[4.625rem] items-center justify-center px-[1.875rem] py-[0.625rem] rounded-[0.625rem] w-full cursor-pointer hover:opacity-90 transition-opacity"
+              disabled={isProcessing || isOrderSheetLoading}
+              className="bg-[var(--color-mint-0)] flex gap-[0.625rem] h-[4.625rem] items-center justify-center px-[1.875rem] py-[0.625rem] rounded-[0.625rem] w-full cursor-pointer hover:opacity-90 transition-opacity disabled:opacity-50 disabled:cursor-not-allowed"
             >
               <span className="body-b0-sb text-[1.5rem] text-white">
-                결제하기
+                {isProcessing ? '처리 중...' : isOrderSheetLoading ? '로딩 중...' : '결제하기'}
               </span>
             </button>
+            {paymentError && (
+              <p className="body-b2-rg text-[var(--color-red-1)] text-center">
+                {paymentError.message}
+              </p>
+            )}
           </div>
         </div>
       </div>
+
+      {/* 우편번호 검색 모달 */}
+      {isPostcodeOpen && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
+          <div className="bg-white p-6 rounded-lg w-[720px] max-w-[90vw] h-[520px] flex flex-col">
+            <DaumPostcode
+              onComplete={handlePostcodeComplete}
+              autoClose
+            />
+
+            <button
+              className="mt-4 text-sm text-gray-500"
+              onClick={() => setIsPostcodeOpen(false)}
+            >
+              닫기
+            </button>
+          </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/src/services/payment/paymentService.ts
+++ b/src/services/payment/paymentService.ts
@@ -1,0 +1,123 @@
+// 결제 서비스 레이어
+import { createOrder, createOrderSheet } from '../../api/order/orderApi';
+import { verifyPayment } from '../../api/chat/orderApi';
+import type { PaymentResponse, WindowWithIMP } from '../../types/payment/payment';
+
+/**
+ * Portone SDK 로드
+ */
+export const loadPortOneSDK = (): Promise<void> => {
+  return new Promise((resolve, reject) => {
+    const windowWithIMP = window as WindowWithIMP;
+    
+    // 이미 로드되어 있는 경우
+    if (windowWithIMP.IMP) {
+      const IMP = windowWithIMP.IMP;
+      if (!IMP.agency) {
+        IMP.init(import.meta.env.VITE_PORTONE_STORE_ID);
+      }
+      return resolve();
+    }
+
+    // SDK 스크립트 동적 로드
+    const script = document.createElement('script');
+    script.src = 'https://cdn.iamport.kr/v1/iamport.js';
+    script.async = true;
+    script.onload = () => {
+      const IMP = windowWithIMP.IMP;
+      if (!IMP) {
+        return reject(new Error('포트원 SDK 로드 실패'));
+      }
+      IMP.init(import.meta.env.VITE_PORTONE_STORE_ID);
+      resolve();
+    };
+    script.onerror = () => reject(new Error('포트원 SDK 스크립트 로드 실패'));
+    document.body.appendChild(script);
+  });
+};
+
+/**
+ * Portone 결제창 호출
+ */
+export const requestPortonePayment = (
+  params: {
+    merchant_uid: string;
+    name: string;
+    amount: number;
+    buyer_name: string;
+  },
+  callback: (rsp: PaymentResponse) => void
+): void => {
+  const windowWithIMP = window as WindowWithIMP;
+  const IMP = windowWithIMP.IMP;
+  
+  if (!IMP) {
+    throw new Error('포트원 SDK가 로드되지 않았습니다.');
+  }
+
+  IMP.request_pay(
+    {
+      pg: 'html5_inicis',
+      pay_method: 'card',
+      merchant_uid: params.merchant_uid,
+      name: params.name,
+      amount: params.amount,
+      buyer_name: params.buyer_name,
+    },
+    callback
+  );
+};
+
+/**
+ * 주문서 조회
+ */
+export const fetchOrderSheet = async (payload: {
+  item_id: string;
+  option_item_ids: string[];
+  quantity: number;
+}) => {
+  const response = await createOrderSheet(payload);
+  
+  if (response.resultType !== 'SUCCESS' || !response.success) {
+    throw new Error(response.error?.message || '주문서 생성에 실패했습니다.');
+  }
+  
+  return response.success;
+};
+
+/**
+ * 주문 생성
+ */
+export const createOrderRequest = async (payload: {
+  merchant_uid: string;
+  item_id: string;
+  option_item_ids: string[];
+  quantity: number;
+  new_address?: {
+    postal_code: string;
+    address: string;
+    address_detail: string;
+    recipient_name: string;
+    phone: string;
+    address_name: string;
+  };
+  delivery_address_id?: string;
+}) => {
+  const response = await createOrder(payload);
+  
+  if (response.resultType !== 'SUCCESS' || !response.success) {
+    throw new Error(response.error?.message || '주문 생성에 실패했습니다.');
+  }
+  
+  return response.success;
+};
+
+/**
+ * 결제 검증
+ */
+export const verifyPaymentRequest = async (payload: {
+  order_id: string;
+  imp_uid: string;
+}) => {
+  return await verifyPayment(payload);
+};

--- a/src/types/api/market/market.ts
+++ b/src/types/api/market/market.ts
@@ -95,6 +95,7 @@ export interface GetMarketProductDetailResponse {
         reformer: {
             nickname: string;
             order_count: number;
+            review_count: number;
             owner_id: string;
             profile_image: string;
             star: number;

--- a/src/types/api/market/market.ts
+++ b/src/types/api/market/market.ts
@@ -99,6 +99,7 @@ export interface GetMarketProductDetailResponse {
             profile_image: string;
             star: number;
             star_recent_3m: number;
+            bio: string;
         };     
     };
 }

--- a/src/types/api/market/market.ts
+++ b/src/types/api/market/market.ts
@@ -68,9 +68,42 @@ export interface GetMarketProductDetailResponse {
         message: string;
     };  
     success: {
-        item: MarketProductItem[];
+        category: {
+            major: string;
+            sub: string;
+        };
+        
+        title: string;
+        content: string;
+        delivery: number;
+        delivery_info: string;
+        images: string[];
+        item_id: string;
+        price: number;
+        is_wished: boolean;
+        option_groups: {
+            option_group_id: string;
+            name: string;
+            option_items: {
+                option_item_id: string;
+                name: string;
+                extra_price: number;
+                quantity: number;
+                is_sold_out: boolean;
+            }[];
+        }[];
+        reformer: {
+            nickname: string;
+            order_count: number;
+            owner_id: string;
+            profile_image: string;
+            star: number;
+            star_recent_3m: number;
+        };     
     };
 }
+
+
 
 
 

--- a/src/types/api/market/market.ts
+++ b/src/types/api/market/market.ts
@@ -102,6 +102,61 @@ export interface GetMarketProductDetailResponse {
         };     
     };
 }
+// 상품 리뷰 목록 조회 
+export interface MarketProductReviewListRequest {
+    itemId: string;
+    page: number;
+    limit: number;
+    sort: 'latest' | 'star_high' | 'star_low';
+}
+export interface MarketProductReviewListResponse {
+
+    success: {
+        reviews: {
+            review_id: string;
+            user_profile_image: string;
+            user_nickname: string;
+            star: number;
+            created_at: string;
+            content: string;
+            product_thumbnail: string;
+            photos: string[];
+        }[];
+        total_count: number;
+        avg_star: number;
+        page: number;
+        limit: number;
+        total_pages: number;
+        has_next_page: boolean;
+        has_prev_page: boolean;
+    };
+}
+   
+
+
+
+
+//마켓 상품 사진 후기 조회
+export interface MarketProductPhotoReviewRequest {
+    itemId: string;
+    offset: number;
+    limit: number;
+}
+
+export interface MarketProductPhotoReviewResponse {  
+    success: {
+        photos: {
+            photo_index: number;
+            review_id: string;
+            photo_url: string;
+            photo_order: number;
+        }[];
+        has_more: boolean;
+        offset: number;
+        limit: number;
+        total_count: number;     
+    };
+}
 
 
 

--- a/src/types/payment/payment.ts
+++ b/src/types/payment/payment.ts
@@ -1,0 +1,69 @@
+// 결제 관련 타입 정의
+
+// Portone SDK 타입 정의
+export interface IMP {
+  init: (storeId: string) => void;
+  request_pay: (
+    params: PaymentRequestParams,
+    callback: (rsp: PaymentResponse) => void
+  ) => void;
+  agency?: string;
+}
+
+export interface PaymentRequestParams {
+  pg: string;
+  pay_method: string;
+  merchant_uid: string;
+  name: string;
+  amount: number;
+  buyer_name: string;
+}
+
+export interface PaymentResponse {
+  success: boolean;
+  error_msg?: string;
+  imp_uid?: string;
+  paid_amount?: number;
+}
+
+export interface WindowWithIMP extends Window {
+  IMP?: IMP;
+}
+
+// 배송지 정보
+export interface DeliveryAddress {
+  zipcode: string;
+  address: string;
+  detailAddress: string;
+  name: string;
+  recipient: string;
+  phone: string;
+}
+
+// 결제 상태
+export const PaymentStatus = {
+  IDLE: 'IDLE',
+  PROCESSING: 'PROCESSING',
+  SUCCESS: 'SUCCESS',
+  FAILED: 'FAILED',
+} as const;
+
+export type PaymentStatus = typeof PaymentStatus[keyof typeof PaymentStatus];
+
+// 결제 에러 타입
+export const PaymentErrorType = {
+  VALIDATION_ERROR: 'VALIDATION_ERROR',
+  ORDER_SHEET_ERROR: 'ORDER_SHEET_ERROR',
+  ORDER_CREATE_ERROR: 'ORDER_CREATE_ERROR',
+  PORTONE_LOAD_ERROR: 'PORTONE_LOAD_ERROR',
+  PORTONE_PAYMENT_ERROR: 'PORTONE_PAYMENT_ERROR',
+  VERIFICATION_ERROR: 'VERIFICATION_ERROR',
+} as const;
+
+export type PaymentErrorType = typeof PaymentErrorType[keyof typeof PaymentErrorType];
+
+export interface PaymentError {
+  type: PaymentErrorType;
+  message: string;
+  originalError?: Error;
+}

--- a/src/utils/payment/formatPaymentDate.ts
+++ b/src/utils/payment/formatPaymentDate.ts
@@ -1,0 +1,8 @@
+export const formatApprovedAt = (date: Date): string => {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  const hours = String(date.getHours()).padStart(2, '0');
+  const minutes = String(date.getMinutes()).padStart(2, '0');
+  return `${year}.${month}.${day} ${hours}.${minutes}`;
+};


### PR DESCRIPTION
## 📌 PR 개요
> 마켓 상세 페이지 결제 api 추가

## 🎯 작업 내용
1. 마켓 상세 페이지 API 연동
- 상품 상세 정보 조회 API 연동
- 사진 후기 조회 기능 추가
- 일반 후기 목록 조회 및 필터링 기능 구현
- 리폼러 프로필 정보 표시 및 네비게이션 추가
2. 결제 시스템 구현
- 결제 서비스 레이어 분리 (paymentService.ts)
- 주문서 조회 API 연동 (useOrderSheet)
- 결제 처리 커스텀 훅 구현 (usePayment)
- Portone(아임포트) SDK 연동
- 결제 검증 로직 구현
3. 구매 페이지 구현
- 배송지 정보 입력 기능
- 우편번호 검색 (Daum Postcode API)
- 주문 정보 및 결제 금액 표시
- 결제 완료 페이지 연동

## 🔗 관련 이슈 / 티켓
- Close #

## 🧩 작업 범위
- [ ] UI
- [x] API 연동
- [ ] 상태 관리
- [ ] 라우팅
- [ ] 공용 컴포넌트
- [ ] 스타일

## 📸 스크린샷 / 영상
| Before | After |
|--------|--------|
|        |        |


## ⚠️ 리뷰어에게 요청할 사항
> 특히 봐줬으면 하는 부분을 적어주세요.
- 

## 🚨 주의사항 / 배포 전 체크
- [ ] console.log 제거
- [ ] 불필요한 주석 제거
- [ ] 환경변수(.env) 변경 없음
- [ ] 타입 에러 없음
