### PR TITLE
fix: 리폼러 결제 막기

### DIFF
--- a/src/components/domain/chat/ChatRoom.tsx
+++ b/src/components/domain/chat/ChatRoom.tsx
@@ -809,6 +809,7 @@ const ChatRoom: React.FC<ChatRoomProps> = ({ chatId, myRole, roomType }) => {
                     )}
                     {msg.messageType === 'payment' && (
                       <PaymentCard
+                        role={myRole}
                         type={isMine ? 'sent' : 'received'}
                         nickname={
                           isMine

--- a/src/components/domain/chat/PaymentCard.tsx
+++ b/src/components/domain/chat/PaymentCard.tsx
@@ -6,6 +6,7 @@ export interface PaymentCardProps {
   nickname: string;
   type: 'sent' | 'received';
   payload: PaymentPayload;
+  role: 'USER' | 'REFORMER';
   onFinish?: (payload: PaymentPayload) => void;
 }
 
@@ -14,8 +15,10 @@ const PaymentCard: React.FC<PaymentCardProps> = ({
   nickname,
   payload,
   onFinish,
+  role,
 }) => {
   const isSent = type === 'sent';
+  const isReformer = role === 'REFORMER';
   const displayNickname = nickname || '심심한 리본';
 
   const { price, delivery, expectedWorking: days, receiptNumber } = payload;
@@ -48,7 +51,9 @@ const PaymentCard: React.FC<PaymentCardProps> = ({
   };
 
   const handlePaymentClick = async () => {
-    if (!receiptNumber) return alert('결제 정보를 불러오지 못했습니다.');
+    if (role === 'REFORMER') {
+      return alert('리폼러는 결제를 진행할 수 없습니다.');
+    }
 
     try {
       await loadPortOne();
@@ -143,7 +148,7 @@ const PaymentCard: React.FC<PaymentCardProps> = ({
           onClick={handlePaymentClick}
           className="w-full bg-black text-white py-3 rounded-xl body-b4-sb transition-colors cursor-pointer"
         >
-          결제창으로 이동하기
+          {isReformer ? '리폼러는 결제할 수 없습니다' : '결제창으로 이동하기'}
         </button>
       </div>
     </div>


### PR DESCRIPTION
## 📌 PR 개요
> 이 PR에서 무엇을 했는지 한 줄로 요약해주세요.
리폼러 결제 막기

## 🎯 작업 내용
- 리폼러가 결제를 진행하려 할 때, 결제를 막고 사전에 문구를 변경함

## 🔗 관련 이슈 / 티켓
- Close #

## 🧩 작업 범위
- [x] UI
- [ ] API 연동
- [x] 상태 관리
- [ ] 라우팅
- [ ] 공용 컴포넌트
- [ ] 스타일

## 📸 스크린샷 / 영상
<img width="2865" height="1529" alt="image" src="https://github.com/user-attachments/assets/6f76a9f9-a7f2-41d8-bf21-d0ebe4a9cc82" />
<img width="2840" height="1525" alt="image" src="https://github.com/user-attachments/assets/da145a48-1851-40e3-9591-386efa800b0d" />

## ⚠️ 리뷰어에게 요청할 사항
> 특히 봐줬으면 하는 부분을 적어주세요.
- 

## 🚨 주의사항 / 배포 전 체크
- [x] console.log 제거
- [x] 불필요한 주석 제거
- [x] 환경변수(.env) 변경 없음
- [x] 타입 에러 없음
