### PR TITLE
[FIX] 커스텀 카테고리 홈 url 재수정

### DIFF
--- a/src/components/common/card/MarketCard.tsx
+++ b/src/components/common/card/MarketCard.tsx
@@ -145,7 +145,7 @@ const MarketCard = ({
 
   const linkTo = to ?? (isMarketItem 
     ? `${MARKET_DETAIL_PATH}/${item.item_id}`
-    : `/proposal/${item.proposal_id}`);
+    : `/order/requests/${item.proposal_id}`);
 
   const content = (
     <div className="bg-white rounded-[1.25rem] overflow-visible cursor-pointer">

--- a/src/components/common/card/MarketCard.tsx
+++ b/src/components/common/card/MarketCard.tsx
@@ -145,7 +145,7 @@ const MarketCard = ({
 
   const linkTo = to ?? (isMarketItem 
     ? `${MARKET_DETAIL_PATH}/${item.item_id}`
-    : `/order/requests/${item.proposal_id}`);
+    : `/order/proposals/${item.proposal_id}`);
 
   const content = (
     <div className="bg-white rounded-[1.25rem] overflow-visible cursor-pointer">

--- a/src/pages/home/Home.tsx
+++ b/src/pages/home/Home.tsx
@@ -74,7 +74,7 @@ const Home = () => {
       </div>
 
       <div className='mt-[7.8rem] mx-[9.375rem]'>
-      <div className='heading-h1-bd  flex flex-col'>
+      <div className='heading-h2-bd  flex flex-col'>
         <p>내 폼을 나답게!</p>
         <p>나에게 딱 맞는 <span className='text-[var(--color-mint-1)]'>리폼 스타일</span>을 찾아보세요</p>
       </div>


### PR DESCRIPTION
## 📌 PR 개요
> 커스텀 카테고리 홈 url 재수정

## 🎯 작업 내용
- 커스텀 카테고리 홈 url 재수정
- `/order/proposals/${item.proposal_id}`)

## 🔗 관련 이슈 / 티켓
- Close #

## 🧩 작업 범위
- [x] UI
- [ ] API 연동
- [ ] 상태 관리
- [ ] 라우팅
- [ ] 공용 컴포넌트
- [ ] 스타일

## 📸 스크린샷 / 영상
| Before | After |
|--------|--------|
|        |        |


## ⚠️ 리뷰어에게 요청할 사항
> 특히 봐줬으면 하는 부분을 적어주세요.
- 

## 🚨 주의사항 / 배포 전 체크
- [x] console.log 제거
- [x] 불필요한 주석 제거
- [x] 환경변수(.env) 변경 없음
- [x] 타입 에러 없음
